### PR TITLE
Log the config params to wandb

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.distributed import init_process_group, destroy_process_group
 
 from model import GPTConfig, GPT
+from utils import guess_config
 
 # -----------------------------------------------------------------------------
 # default config values
@@ -34,7 +35,7 @@ eval_only = False # if True, script exits right after the first eval
 always_save_checkpoint = True # if True, always save a checkpoint after each eval
 # wandb logging
 wandb_log = False # disabled by default
-wandb_entity = 'karpathy'
+wandb_entity = None
 wandb_project = 'owt'
 wandb_run_name = 'gpt2' # 'run' + str(time.time())
 # data
@@ -212,12 +213,7 @@ def get_lr(iter):
 
 # logging
 if wandb_log and gpu_id == 0:
-    wandb.init(project=wandb_project, entity=wandb_entity, name=wandb_run_name)
-    wandb.config = {
-        "batch_size": batch_size,
-        "block_size": block_size,
-        "learning_rate": learning_rate, # TODO log everything else too
-    }
+    wandb.init(project=wandb_project, entity=wandb_entity, name=wandb_run_name, config=guess_config(globals()))
 
 # training loop
 t0 = time.time()

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,12 @@
+import json
+
+def is_jsonable(x):
+    try:
+        json.dumps(x)
+        return True
+    except:
+        return False
+
+def guess_config(d):
+    f = dict(filter(lambda e: not str(e[0]).startswith("__") and is_jsonable(e[1]), d.items()))
+    return f 


### PR DESCRIPTION
This PR logs the parameters living on the global scope as a config to W&B. This is a greedy solution, as the parameters live on the global scope. I do that by checking which params are JSON serializable and filtering out the stuff that starts with dunder:

```python
def guess_config(d):
    "Grab config from globals"
    f = dict(filter(lambda e: not str(e[0]).startswith("__") and is_jsonable(e[1]), d.items()))
    return f 
```
I put everything into a `utils.py` file, but you can bring them in. You can see the logged `config` on the overview tab now.

- Another small change, I defaulted the `wandb_entity` to None, this way, runs will go to the current logged user.

![globals](https://user-images.githubusercontent.com/18441985/210543051-b7b28fc0-e041-4fc9-b303-63bfb1d75bb1.gif)
