### PR TITLE
Make wandb import conditioned to wandb_log=True

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Dependencies:
 - `pip install tiktoken` for OpenAI's fast BPE code <3
 - `pip install wandb` for optional logging <3
 - `pip install tqdm`
-- `pip install networkx`
 
 ## usage
 

--- a/train.py
+++ b/train.py
@@ -13,7 +13,6 @@ import os
 import time
 import math
 
-import wandb
 import numpy as np
 import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
@@ -75,6 +74,9 @@ if gpu_id == 0:
 torch.manual_seed(1337 + gpu_id) # note: each worker gets a different seed
 torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
 torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
+# import wandb conditionally
+if wandb_log:
+    import wandb
 
 # poor man's data loader, TODO evaluate need for actual DataLoader
 data_dir = os.path.join('data', dataset)

--- a/train.py
+++ b/train.py
@@ -74,9 +74,6 @@ if gpu_id == 0:
 torch.manual_seed(1337 + gpu_id) # note: each worker gets a different seed
 torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
 torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
-# import wandb conditionally
-if wandb_log:
-    import wandb
 
 # poor man's data loader, TODO evaluate need for actual DataLoader
 data_dir = os.path.join('data', dataset)
@@ -182,6 +179,7 @@ def get_lr(iter):
 
 # logging
 if wandb_log and gpu_id == 0:
+    import wandb
     wandb.init(project=wandb_project, name=wandb_run_name)
     wandb.config = {
         "batch_size": batch_size,


### PR DESCRIPTION
In the spirit of keeping dependencies minimal, there's no need to pip install and import `wandb` when `wandb_log=False`. Also `networkx` doesn't seem to be used in the codebase.