### PR TITLE
Tie LM Head Weight to Token Embedding to match official GPT2 Code

### DIFF
--- a/model.py
+++ b/model.py
@@ -231,6 +231,7 @@ class GPT(nn.Module):
                 elif pn.endswith('weight') and isinstance(m, whitelist_weight_modules):
                     if fpn.startswith('lm_head'):
                         # lm_head weight is tied to token embedding weight
+                        # its weight decay is handled the same as wte.weight
                         pass 
                     else:
                         # weights of whitelist modules will be weight decayed

--- a/model.py
+++ b/model.py
@@ -229,8 +229,12 @@ class GPT(nn.Module):
                     # all biases will not be decayed
                     no_decay.add(fpn)
                 elif pn.endswith('weight') and isinstance(m, whitelist_weight_modules):
-                    # weights of whitelist modules will be weight decayed
-                    decay.add(fpn)
+                    if fpn.startswith('lm_head'):
+                        # lm_head weight is tied to token embedding weight
+                        pass 
+                    else:
+                        # weights of whitelist modules will be weight decayed
+                        decay.add(fpn)
                 elif pn.endswith('weight') and isinstance(m, blacklist_weight_modules):
                     # weights of blacklist modules will NOT be weight decayed
                     no_decay.add(fpn)

--- a/model.py
+++ b/model.py
@@ -119,7 +119,7 @@ class GPT(nn.Module):
         # lm_head weight is transpose of token embedding weight
         self.lm_head.weight = self.transformer.wte.weight
 
-        # report number of parameters (don't count decoder parameters in head as they are shared with wte weight)
+        # report number of parameters (don't count decoder parameters in lm_head as they are shared with wte weight)
         n_params = sum(p.numel() for p in self.transformer.parameters())
         print("number of parameters: %.2fM" % (n_params/1e6,))
 

--- a/model.py
+++ b/model.py
@@ -116,7 +116,10 @@ class GPT(nn.Module):
         ))
         self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
 
-        # report number of parameters (note we don't count the decoder parameters in lm_head)
+        # lm_head weight is transpose of token embedding weight
+        self.lm_head.weight = self.transformer.wte.weight
+
+        # report number of parameters (don't count decoder parameters in head as they are shared with wte weight)
         n_params = sum(p.numel() for p in self.transformer.parameters())
         print("number of parameters: %.2fM" % (n_params/1e6,))
 


### PR DESCRIPTION
This PR updates the GPT2 lm_head weight by linking it to the token embedding weights. This is done in the official GPT2 TF implementation [here](https://github.com/openai/gpt-2/blob/master/src/model.py#L171).  