### PR TITLE
Use argparse in configurator.py

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -1,5 +1,5 @@
 """
-Poor Man's Configurator. Probably a terrible idea. Example usage:
+Middle Class Man's Configurator. Probably a bad idea. Example usage:
 $ python train.py config/override_file.py --batch_size=32
 this will first run config/override_file.py, then override batch_size to 32
 
@@ -7,41 +7,49 @@ The code in this file will be run as follows from e.g. train.py:
 >>> exec(open('configurator.py').read())
 
 So it's not a Python module, it's just shuttling this code away from train.py
-The code in this script then overrides the globals()
+The code in this script then overrides the globals(), using argparse to parse
+arguments from the command line and a config file.
 
 I know people are not going to love this, I just really dislike configuration
 complexity and having to prepend config. to every single variable. If someone
 comes up with a better simple Python solution I am all ears.
 """
 
-import sys
 from ast import literal_eval
+import argparse
+import types
 
-for arg in sys.argv[1:]:
-    if '=' not in arg:
-        # assume it's the name of a config file
-        assert not arg.startswith('--')
-        config_file = arg
-        print(f"Overriding config with {config_file}:")
-        with open(config_file) as f:
-            print(f.read())
-        exec(open(config_file).read())
-    else:
-        # assume it's a --key=value argument
-        assert arg.startswith('--')
-        key, val = arg.split('=')
-        key = key[2:]
-        if key in globals():
-            try:
-                # attempt to eval it it (e.g. if bool, number, or etc)
-                attempt = literal_eval(val)
-            except (SyntaxError, ValueError):
-                # if that goes wrong, just use the string
-                attempt = val
-            # ensure the types match ok
-            assert type(attempt) == type(globals()[key])
-            # cross fingers
-            print(f"Overriding: {key} = {attempt}")
-            globals()[key] = attempt
-        else:
-            raise ValueError(f"Unknown config key: {key}")
+current_globals = globals().copy()
+
+parser = argparse.ArgumentParser(formatter_class=argparse.MetavarTypeHelpFormatter)
+parser.add_argument('config_file', nargs='?', type=str, default=None, help='Python config file to override defaults')
+
+
+# Custom type for tuples, which aren't conventionally supported by argparse
+def tuple_arg(val):
+    val = val.replace("(", "").replace(")", "")
+    parsed_val = val.split(",")
+    return tuple([literal_eval(x.strip()) for x in parsed_val])
+
+type_ignore_list = [types.FunctionType, types.ModuleType, type]
+
+for glob in current_globals:
+    if not glob.startswith('__') and not any(isinstance(current_globals[glob], t) for t in type_ignore_list):
+        value = current_globals[glob]
+        actual_type = type(current_globals[glob])
+        tuple_helper_text = f",  to pass surround in quotes e.g. --{glob}='{value}'" if actual_type == tuple else ""
+        parser_val_type = actual_type if actual_type != tuple else tuple_arg
+        parser.add_argument(f'--{glob}', type=parser_val_type, help=f"default: {value}" + tuple_helper_text, default=None)
+
+args = parser.parse_args()
+
+if args.config_file is not None:
+    print(f"Overriding config with {args.config_file}:")
+    with open(args.config_file) as f:
+        print(f.read())
+    exec(open(args.config_file).read())
+
+for k, v in vars(args).items():
+    if k != 'config_file' and v is not None:
+        print(f"Overriding: {k} = {v}")
+        globals()[k] = v


### PR DESCRIPTION
I really liked the simplicity of the globals() approach, this is one small improvement that adds argparse support, which gives a few things for free:

* `python train.py -h` now returns arg + types, along with default values (see paste below)
* typechecking happens inside argparse + gives clear error messages

Unfortunately, had to add a hack for the `betas` parameter since it's a tuple, which isn't natively supported with argparse. If we're fine switching to `beta1` and `beta2`, then we can even remove the `literal_eval` and clean up the code significantly.

Output examples:

`python train.py -h` ->

```
nanoGPT git:(configurator-argparse) ✗ python train.py -h
usage: train.py [-h] [--out_dir str] [--eval_interval int] [--log_interval int] [--eval_iters int] [--eval_only bool] [--always_save_checkpoint bool]
                [--init_from str] [--wandb_log bool] [--wandb_project str] [--wandb_run_name str] [--dataset str] [--batch_size int] [--block_size int]
                [--n_layer int] [--n_head int] [--n_embd int] [--dropout float] [--learning_rate float] [--max_iters int] [--weight_decay float]
                [--betas tuple_arg] [--decay_lr bool] [--warmup_iters int] [--lr_decay_iters int] [--min_lr float] [--backend str] [--device str] [--dtype str]
                [--compile bool]
                [str]

positional arguments:
  str                   Python config file to override defaults

optional arguments:
  -h, --help            show this help message and exit
  --out_dir str         default: out
  --eval_interval int   default: 2000
  --log_interval int    default: 1
  --eval_iters int      default: 200
  --eval_only bool      default: False
  --always_save_checkpoint bool
                        default: True
  --init_from str       default: scratch
  --wandb_log bool      default: False
  --wandb_project str   default: owt
  --wandb_run_name str  default: gpt2
  --dataset str         default: openwebtext
  --batch_size int      default: 12
  --block_size int      default: 1024
  --n_layer int         default: 12
  --n_head int          default: 12
  --n_embd int          default: 768
  --dropout float       default: 0.0
  --learning_rate float
                        default: 0.0006
  --max_iters int       default: 600000
  --weight_decay float  default: 0.01
  --betas tuple_arg     default: (0.9, 0.95), to pass surround in quotes e.g. --betas='(0.9, 0.95)'
  --decay_lr bool       default: True
  --warmup_iters int    default: 2000
  --lr_decay_iters int  default: 600000
  --min_lr float        default: 6e-05
  --backend str         default: nccl
  --device str          default: cuda
  --dtype str           default: bfloat16
  --compile bool        default: True
```


`python sample.py -h` ->

```
(spacy) ➜  nanoGPT git:(configurator-argparse) ✗ python sample.py -h
usage: sample.py [-h] [--out_dir str] [--start str] [--num_samples int] [--max_new_tokens int] [--temperature float] [--top_k int] [--seed int] [--device str]
                 [--dtype str] [--compile bool]
                 [str]

positional arguments:
  str                   Python config file to override defaults

optional arguments:
  -h, --help            show this help message and exit
  --out_dir str         default: out
  --start str           default:
  --num_samples int     default: 10
  --max_new_tokens int  default: 500
  --temperature float   default: 0.8
  --top_k int           default: 200
  --seed int            default: 1337
  --device str          default: cuda
  --dtype str           default: bfloat16
  --compile bool        default: False
```

other examples of usage:

```
>>> python train.py config/eval_gpt2.py

Overriding config with config/eval_gpt2.py:
# evaluate the base gpt2
# n_layer=12, n_head=12, n_embd=768
# 124M parameters
batch_size = 8
eval_iters = 500 # use more iterations to get good estimate
eval_only = True
wandb_log = False
init_from = 'gpt2'
```

keyword usage:

```
>>> python train.py --wandb_log=False --init_from='gpt-4'
Overriding: init_from = gpt-4
Overriding: wandb_log = True
```

error message:

```
>>> python train.py --wandb_log=False --batch_size='hello'
usage: train.py [-h] [--out_dir str] [--eval_interval int] [--log_interval int] [--eval_iters int] [--eval_only bool] [--always_save_checkpoint bool]
                [--init_from str] [--wandb_log bool] [--wandb_project str] [--wandb_run_name str] [--dataset str] [--batch_size int] [--block_size int]
                [--n_layer int] [--n_head int] [--n_embd int] [--dropout float] [--learning_rate float] [--max_iters int] [--weight_decay float]
                [--betas tuple_arg] [--decay_lr bool] [--warmup_iters int] [--lr_decay_iters int] [--min_lr float] [--backend str] [--device str] [--dtype str]
                [--compile bool]
                [str]
train.py: error: argument --batch_size: invalid int value: 'hello'
```