### PR TITLE
Minor change to allow using ddp with exclusive process mode 

### DIFF
--- a/train.py
+++ b/train.py
@@ -85,6 +85,7 @@ if ddp:
     ddp_rank = int(os.environ['RANK'])
     ddp_local_rank = int(os.environ['LOCAL_RANK'])
     device = f'cuda:{ddp_local_rank}'
+    torch.cuda.set_device(device)
     master_process = ddp_rank == 0 # this process will do logging, checkpointing etc.
     seed_offset = ddp_rank # each process gets a different seed
 else:


### PR DESCRIPTION
I’ve been trying to run this code on a HPC node with 4 gpus, however after compiling the model it would immediately run into `RuntimeError: CUDA error: CUDA-capable device(s) is/are busy or unavailable`. 
After a lot debugging (i thought there was something wrong with the environment setup) it seems the only problem is the GPUs are in exclusive process mode. Following the suggestion from the [DistributedDataParallel docs](https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html) to use torch.cuda.set_device everything works fine.


>To use DistributedDataParallel on a host with N GPUs, you should spawn up N processes, ensuring that each process exclusively works on a single GPU from 0 to N-1. This can be done by either setting CUDA_VISIBLE_DEVICES for every process or by calling:
> `torch.cuda.set_device(i)`
