### PR TITLE
fix for training stability on single GPU

### DIFF
--- a/train.py
+++ b/train.py
@@ -45,7 +45,7 @@ wandb_project = 'owt'
 wandb_run_name = 'gpt2' # 'run' + str(time.time())
 # data
 dataset = 'openwebtext'
-gradient_accumulation_steps = 1 # used to simulate larger batch sizes
+gradient_accumulation_steps = 5 # used to simulate larger batch sizes
 batch_size = 12 # if gradient_accumulation_steps > 1, this is the micro-batch size
 block_size = 1024
 # model
@@ -92,6 +92,7 @@ else:
     # if not ddp, we are running on a single gpu, and one process
     master_process = True
     seed_offset = 0
+    gradient_accumulation_steps *= 8 # simulate 8 gpus
 
 if master_process:
     os.makedirs(out_dir, exist_ok=True)


### PR DESCRIPTION
I'm trying to make single-GPU train with the same loss results as your 8x GPU training that is in the graph in the readme. Currently, single-GPU training gets much worse loss and then blows up. There is some discussion on Discord/nanoGPT - it's not just me. :)

This PR only partially deals with the problem. :/ It won't deal with a 2x GPU system correctly... only 8x or 1x. But it's better than what is currently there. I tested this by running it on 8xA100/Lambda labs, and a 1x 4090 on my home desktop. The loss curves match very well and I'd imagine the difference is due to floating point precision.