### PR TITLE
non flash attention: speedup by avoiding ddp broadcasts of causal mask

### DIFF
--- a/model.py
+++ b/model.py
@@ -151,6 +151,9 @@ class GPT(nn.Module):
             if pn.endswith('c_proj.weight'):
                 torch.nn.init.normal_(p, mean=0.0, std=0.02/math.sqrt(2 * config.n_layer))
 
+        # when flash == False: this excludes the causal mask from being broadcasted across ranks when using ddp
+        self._ddp_params_and_buffers_to_ignore = [f"transformer.h.{i}.attn.bias" for i in range(config.n_layer)]
+
         # report number of parameters
         print("number of parameters: %.2fM" % (self.get_num_params()/1e6,))
 


### PR DESCRIPTION
In the manual implementation of causal self-attention, the causal mask is registered as a buffer, which causes DDP to broadcast it at every step. Excluding it from being broadcasted gives some extra speedup (up to 8% in a 8x3090 setup with fake data, probably more for multinode)

In fact, the causal masks are the only buffers in this model, so you can also set `broadcast_buffers=False` in train.py:L201 but that could potentially backfire if other buffers that need syncing are introduced in the future.