### PR TITLE
Add Linear batch_size Scheduler

### DIFF
--- a/config/train_gpt2.py
+++ b/config/train_gpt2.py
@@ -8,7 +8,9 @@ wandb_run_name='gpt2-124M'
 
 # these make the total batch size be ~0.5M
 # 12 batch size * 1024 block size * 5 gradaccum * 8 GPUs = 491,520
+# batch schedule increases to batch_size given when enabled 
 batch_size = 12
+batch_schedule_increase = True
 block_size = 1024
 gradient_accumulation_steps = 5
 

--- a/config/train_gpt2.py
+++ b/config/train_gpt2.py
@@ -10,7 +10,10 @@ wandb_run_name='gpt2-124M'
 # 12 batch size * 1024 block size * 5 gradaccum * 8 GPUs = 491,520
 # batch schedule increases to batch_size given when enabled 
 batch_size = 12
-batch_schedule_increase = True
+batch_schedule_increase = False
+batch_size_max_iter = 400000 # batch_size will be at a max at this iter (typically <=max_iter)
+batch_size_initial = 4 # starting batch_size
+
 block_size = 1024
 gradient_accumulation_steps = 5
 

--- a/config/train_shakespeare_char.py
+++ b/config/train_shakespeare_char.py
@@ -16,7 +16,10 @@ wandb_run_name = 'mini-gpt'
 # batch schedule increases to batch_size given when enabled
 dataset = 'shakespeare_char'
 batch_size = 64
-batch_size_schedule = True
+batch_size_schedule = False # when scheduler is on, batch_size is treated as the max value. 
+batch_size_max_iter = 100 # batch_size will be at a max at this iter (typically <=max_iter)
+batch_size_initial = 4 # starting batch_size
+
 block_size = 256 # context of up to 256 previous characters
 
 # baby GPT model :)

--- a/config/train_shakespeare_char.py
+++ b/config/train_shakespeare_char.py
@@ -13,8 +13,10 @@ wandb_log = False # override via command line if you like
 wandb_project = 'shakespeare-char'
 wandb_run_name = 'mini-gpt'
 
+# batch schedule increases to batch_size given when enabled
 dataset = 'shakespeare_char'
 batch_size = 64
+batch_size_schedule = True
 block_size = 256 # context of up to 256 previous characters
 
 # baby GPT model :)

--- a/train.py
+++ b/train.py
@@ -108,6 +108,7 @@ device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.aut
 # note: float16 data type will automatically use a GradScaler
 ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
 ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
+
 # batch size scheduler
 if batch_size_schedule: 
     batch_size_max = batch_size
@@ -259,7 +260,6 @@ while True:
     lr = get_lr(iter_num) if decay_lr else learning_rate
     # determine and set the batch_size for this iteration 
     batch_size = get_batch_size(iter_num) if batch_size_schedule else batch_size 
-    print(batch_size) 
     for param_group in optimizer.param_groups:
         param_group['lr'] = lr
 


### PR DESCRIPTION
## What Changed 
- adds to configs option to train configs 
- linearly increases the training batch_size until max batch_size is reached. 
## Testing 
- verified training works with/without batch_size scheduler 
## Notes 
- closes one of the TODOs mentioned in the readme. 