### PR TITLE
Allow saving checkpoints for the best and the latest evaluation

### DIFF
--- a/train.py
+++ b/train.py
@@ -241,6 +241,21 @@ t0 = time.time()
 local_iter_num = 0 # number of iterations in the lifetime of this process
 raw_model = model.module if ddp else model # unwrap DDP container if needed
 running_mfu = -1.0
+
+# helps saving checkpoint to a file
+def save_checkpoint(ckpt_file_name):
+    checkpoint = {
+        'model': raw_model.state_dict(),
+        'optimizer': optimizer.state_dict(),
+        'model_args': model_args,
+        'iter_num': iter_num,
+        'best_val_loss': best_val_loss,
+        'config': config,
+    }
+    ckpt_file_path = os.path.join(out_dir, ckpt_file_name)
+    print(f"saving checkpoint to {ckpt_file_path}")
+    torch.save(checkpoint, ckpt_file_path)
+
 while True:
 
     # determine and set the learning rate for this iteration
@@ -260,19 +275,12 @@ while True:
                 "lr": lr,
                 "mfu": running_mfu*100, # convert to percentage
             })
-        if losses['val'] < best_val_loss or always_save_checkpoint:
+        if losses['val'] < best_val_loss:
             best_val_loss = losses['val']
             if iter_num > 0:
-                checkpoint = {
-                    'model': raw_model.state_dict(),
-                    'optimizer': optimizer.state_dict(),
-                    'model_args': model_args,
-                    'iter_num': iter_num,
-                    'best_val_loss': best_val_loss,
-                    'config': config,
-                }
-                print(f"saving checkpoint to {out_dir}")
-                torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
+                save_checkpoint('ckpt.pt')
+        if always_save_checkpoint:
+            save_checkpoint('last_eval_ckpt.pt')
     if iter_num == 0 and eval_only:
         break
 


### PR DESCRIPTION
Extracting the checkpoint saving logic into a method will allow for saving the best checkpoint as before, but also the latest checkpoint if the `always_save_checkpoint` flag is set to `True`. The latest checkpoint should not overwrite the best one, as these are two different points at which the model has been at.