### PR TITLE
Enable sdpa for nonzero dropout

### DIFF
--- a/model.py
+++ b/model.py
@@ -49,10 +49,10 @@ class CausalSelfAttention(nn.Module):
         self.n_head = config.n_head
         self.n_embd = config.n_embd
         self.dropout = config.dropout
-        # flash attention make GPU go brrrrr but support is only in PyTorch nightly and still a bit scary
-        self.flash = hasattr(torch.nn.functional, 'scaled_dot_product_attention') and self.dropout == 0.0
+        # flash attention make GPU go brrrrr but support is only in PyTorch >= 2.0
+        self.flash = hasattr(torch.nn.functional, 'scaled_dot_product_attention')
         if not self.flash:
-            print("WARNING: using slow attention. Flash Attention atm needs PyTorch nightly and dropout=0.0")
+            print("WARNING: using slow attention. Flash Attention requires PyTorch >= 2.0")
             # causal mask to ensure that attention is only applied to the left in the input sequence
             self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size))
                                         .view(1, 1, config.block_size, config.block_size))


### PR DESCRIPTION
PyTorch supports dropout for FlashAttention in SDPA via this PR: https://github.com/pytorch/pytorch/pull/92917
As well the Math fallback supports dropout as well. On the above PR I also posted some speed numbers of the train script. 
On an single A100 machine and using the shakespeare dataset.

Prior to this PR speeds and feeds:
Dropout: 0.0, w/ torch.compile: 3273.17ms per loop
Dropout: 0.1, w/torch.compile: 4731.11ms per loop.

As of current master branch for PyTorch and this PR:
Dropout: 0.0, w/ torch.compile: 3273.17ms per loop
Dropout: 0.1, w/torch.compile: 3774.39ms per loop. 

The reason for the speed difference is the added need for some dynamo graph_breaks. There is a discussion for the reasoning on the PyTorch pull-request. However still a net win.