### PR TITLE
Model.py simplifications

### DIFF
--- a/model.py
+++ b/model.py
@@ -9,62 +9,61 @@ https://github.com/huggingface/transformers/blob/main/src/transformers/models/gp
 
 import math
 import inspect
+from functools import reduce
 from dataclasses import dataclass
+from typing import Optional
 
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
-# @torch.jit.script # good to enable when not using torch.compile, disable when using (our default)
-def new_gelu(x):
-    """
-    Implementation of the GELU activation function currently in Google BERT repo (identical to OpenAI GPT).
-    Reference: Gaussian Error Linear Units (GELU) paper: https://arxiv.org/abs/1606.08415
-    """
-    return 0.5 * x * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * torch.pow(x, 3.0))))
+class LayerNorm(nn.LayerNorm):
+    """ LayerNorm wrapper with an optional bias. PyTorch doesn't support simply bias=False """
 
-class LayerNorm(nn.Module):
-    """ LayerNorm but with an optional bias. PyTorch doesn't support simply bias=False """
-
-    def __init__(self, ndim, bias):
-        super().__init__()
-        self.weight = nn.Parameter(torch.ones(ndim))
-        self.bias = nn.Parameter(torch.zeros(ndim)) if bias else None
-
-    def forward(self, input):
-        return F.layer_norm(input, self.weight.shape, self.weight, self.bias, 1e-5)
+    def __init__(self, ndim, bias, **kwargs):
+        super().__init__(ndim, **kwargs)
+        self.bias = self.bias if bias else None
 
 class CausalSelfAttention(nn.Module):
 
     def __init__(self, config):
         super().__init__()
-        assert config.n_embd % config.n_head == 0
-        # key, query, value projections for all heads, but in a batch
-        self.c_attn = nn.Linear(config.n_embd, 3 * config.n_embd, bias=config.bias)
-        # output projection
-        self.c_proj = nn.Linear(config.n_embd, config.n_embd, bias=config.bias)
-        # regularization
-        self.attn_dropout = nn.Dropout(config.dropout)
-        self.resid_dropout = nn.Dropout(config.dropout)
+        if config.head_size:
+            self.head_size = config.head_size
+        else:
+            assert config.n_embd % config.n_head == 0
+            self.head_size = config.n_embd // config.n_head
         self.n_head = config.n_head
         self.n_embd = config.n_embd
         self.dropout = config.dropout
+        # key, query, value projections for all heads, but in a batch
+        self.c_attn = nn.Linear(config.n_embd, 3 * self.n_head * self.head_size, bias=config.bias)
+        # output projection
+        self.c_proj = nn.Linear(self.n_head * self.head_size, config.n_embd, bias=config.bias)
+        # regularization
+        self.attn_dropout = nn.Dropout(config.dropout)
+        self.proj_dropout = nn.Dropout(config.dropout)
         # flash attention make GPU go brrrrr but support is only in PyTorch >= 2.0
         self.flash = hasattr(torch.nn.functional, 'scaled_dot_product_attention')
         if not self.flash:
             print("WARNING: using slow attention. Flash Attention requires PyTorch >= 2.0")
             # causal mask to ensure that attention is only applied to the left in the input sequence
-            self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size))
-                                        .view(1, 1, config.block_size, config.block_size))
+            self.register_buffer("bias", torch.tril(torch.ones(1, 1, config.block_size, config.block_size)))
 
     def forward(self, x):
-        B, T, C = x.size() # batch size, sequence length, embedding dimensionality (n_embd)
+        # notation:
+        # B  | batch
+        # T  | time-step (sequence length)
+        # C  | embeddings size
+        # hs | head size
+        # nh | number of heads
+        B, T, C = x.size()
 
         # calculate query, key, values for all heads in batch and move head forward to be the batch dim
-        q, k ,v  = self.c_attn(x).split(self.n_embd, dim=2)
-        k = k.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
-        q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
-        v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
+        q, k ,v  = self.c_attn(x).split(self.n_head * self.head_size, dim=2) # (B, T, C) -> (B, T, 3 * nh * hs) -> 3 * (B, T, nh, hs)
+        k = k.view(B, T, self.n_head, self.head_size).transpose(1, 2) # (B, nh, T, hs)
+        q = q.view(B, T, self.n_head, self.head_size).transpose(1, 2) # (B, nh, T, hs)
+        v = v.view(B, T, self.n_head, self.head_size).transpose(1, 2) # (B, nh, T, hs)
 
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
         if self.flash:
@@ -77,10 +76,10 @@ class CausalSelfAttention(nn.Module):
             att = F.softmax(att, dim=-1)
             att = self.attn_dropout(att)
             y = att @ v # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
-        y = y.transpose(1, 2).contiguous().view(B, T, C) # re-assemble all head outputs side by side
+        y = y.transpose(1, 2).contiguous().view(B, T, self.n_head * self.head_size) # re-assemble all head outputs side by side
 
         # output projection
-        y = self.resid_dropout(self.c_proj(y))
+        y = self.proj_dropout(self.c_proj(y)) # (B, T, nh * hs) -> (B, T, C)
         return y
 
 class MLP(nn.Module):
@@ -88,12 +87,13 @@ class MLP(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.c_fc    = nn.Linear(config.n_embd, 4 * config.n_embd, bias=config.bias)
+        self.gelu    = nn.GELU(approximate='tanh')
         self.c_proj  = nn.Linear(4 * config.n_embd, config.n_embd, bias=config.bias)
         self.dropout = nn.Dropout(config.dropout)
 
     def forward(self, x):
         x = self.c_fc(x)
-        x = new_gelu(x)
+        x = self.gelu(x)
         x = self.c_proj(x)
         x = self.dropout(x)
         return x
@@ -117,6 +117,7 @@ class GPTConfig:
     block_size: int = 1024
     vocab_size: int = 50304 # GPT-2 vocab_size of 50257, padded up to nearest multiple of 64 for efficiency
     n_layer: int = 12
+    head_size: Optional[int] = None
     n_head: int = 12
     n_embd: int = 768
     dropout: float = 0.0
@@ -134,7 +135,7 @@ class GPT(nn.Module):
             wte = nn.Embedding(config.vocab_size, config.n_embd),
             wpe = nn.Embedding(config.block_size, config.n_embd),
             drop = nn.Dropout(config.dropout),
-            h = nn.ModuleList([Block(config) for _ in range(config.n_layer)]),
+            h = nn.Sequential(*[Block(config) for _ in range(config.n_layer)]),
             ln_f = LayerNorm(config.n_embd, bias=config.bias),
         ))
         self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
@@ -175,17 +176,14 @@ class GPT(nn.Module):
             torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
 
     def forward(self, idx, targets=None):
-        device = idx.device
         b, t = idx.size()
         assert t <= self.config.block_size, f"Cannot forward sequence of length {t}, block size is only {self.config.block_size}"
-        pos = torch.arange(0, t, dtype=torch.long, device=device).unsqueeze(0) # shape (1, t)
 
         # forward the GPT model itself
         tok_emb = self.transformer.wte(idx) # token embeddings of shape (b, t, n_embd)
-        pos_emb = self.transformer.wpe(pos) # position embeddings of shape (1, t, n_embd)
+        pos_emb = self.transformer.wpe.weight[None, :t] # position embeddings of shape (1, t, n_embd)
         x = self.transformer.drop(tok_emb + pos_emb)
-        for block in self.transformer.h:
-            x = block(x)
+        x = self.transformer.h(x)
         x = self.transformer.ln_f(x)
 
         if targets is not None:
@@ -279,29 +277,18 @@ class GPT(nn.Module):
         no_decay = set()
         whitelist_weight_modules = (torch.nn.Linear, )
         blacklist_weight_modules = (torch.nn.LayerNorm, LayerNorm, torch.nn.Embedding)
-        for mn, m in self.named_modules():
-            for pn, p in m.named_parameters():
-                fpn = '%s.%s' % (mn, pn) if mn else pn # full param name
-                # random note: because named_modules and named_parameters are recursive
-                # we will see the same tensors p many many times. but doing it this way
-                # allows us to know which parent module any tensor p belongs to...
-                if pn.endswith('bias'):
-                    # all biases will not be decayed
-                    no_decay.add(fpn)
-                elif pn.endswith('weight') and isinstance(m, whitelist_weight_modules):
-                    # weights of whitelist modules will be weight decayed
-                    decay.add(fpn)
-                elif pn.endswith('weight') and isinstance(m, blacklist_weight_modules):
-                    # weights of blacklist modules will NOT be weight decayed
-                    no_decay.add(fpn)
-
-        # subtle: 'transformer.wte.weight' and 'lm_head.weight' are tied, so they
-        # will appear in the no_decay and decay sets respectively after the above.
-        # In addition, because named_parameters() doesn't return duplicates, it
-        # will only return the first occurence, key'd by 'transformer.wte.weight', below.
-        # so let's manually remove 'lm_head.weight' from decay set. This will include
-        # this tensor into optimization via transformer.wte.weight only, and not decayed.
-        decay.remove('lm_head.weight')
+        for pn, _ in self.named_parameters():
+            # get the parent module by the parameter's name
+            module = reduce(lambda module, key: getattr(module, key), pn.split(".")[:-1], self)
+            if pn.endswith('bias'):
+                # all biases will not be decayed
+                no_decay.add(pn)
+            elif pn.endswith('weight') and isinstance(module, whitelist_weight_modules):
+                # weights of whitelist modules will be weight decayed
+                decay.add(pn)
+            elif pn.endswith('weight') and isinstance(module, blacklist_weight_modules):
+                # weights of blacklist modules will NOT be weight decayed
+                no_decay.add(pn)
 
         # validate that we considered every parameter
         param_dict = {pn: p for pn, p in self.named_parameters()}
@@ -313,8 +300,8 @@ class GPT(nn.Module):
 
         # create the pytorch optimizer object
         optim_groups = [
-            {"params": [param_dict[pn] for pn in sorted(list(decay))], "weight_decay": weight_decay},
-            {"params": [param_dict[pn] for pn in sorted(list(no_decay))], "weight_decay": 0.0},
+            {"params": [param_dict[pn] for pn in sorted(decay)], "weight_decay": weight_decay},
+            {"params": [param_dict[pn] for pn in sorted(no_decay)], "weight_decay": 0.0},
         ]
         # new PyTorch nightly has a new 'fused' option for AdamW that is much faster
         use_fused = (device_type == 'cuda') and ('fused' in inspect.signature(torch.optim.AdamW).parameters)
@@ -353,6 +340,8 @@ class GPT(nn.Module):
             # forward the model to get the logits for the index in the sequence
             logits, _ = self(idx_cond)
             # pluck the logits at the final step and scale by desired temperature
+            # temperature controls randomnes of generated tokens:
+            # https://ai.stackexchange.com/questions/32477/what-is-the-temperature-in-the-gpt-models
             logits = logits[:, -1, :] / temperature
             # optionally crop the logits to only the top k options
             if top_k is not None:


### PR DESCRIPTION
*Accidently messed up with the PR and the branch, so let's try one more time*

I really don't like making such somewhat big PRs, but don't want to bombard with small ones either. 

Here are some changes (code simplifications) for model.py file:

1. We don't need a separate function for `gelu` activation function, since it's already [implemented](https://pytorch.org/docs/stable/generated/torch.nn.GELU.html) in PyTorch. In order to have the same behaviour just need to provide `approximate='tanh'`.
2. In order to have LayerNorm with additional bias argument we can simply inherit from `nn.LayerNorm` and disable bias if needed in __init__ method. In my opinion looks cleaner, plus preserve functionality of PyTorch's implementation.
3. Additional `head_size` argument for `CausalSelfAttention` class. In case if we don't want to have `head_size=n_embd//n_head`. If it's not provided (default) - previous behavior. Adds additional parameter to finetune and shapes become more self-explainatory.  Intuition came from [this article](https://jalammar.github.io/illustrated-transformer/).
Note: it's note possible for right now to provide `head_size` as argument in CLI. The expected logic is to have this value (as global value in train.py) as None by default and then override, but because of the checks in configurator.py it's not possible (NoneType will not match with int type). Perhaps I'll make a PR for it later.
4. 'bias' in CausalSelfAttention can be directly created in 4 dimensions. Or it can be created in 2 dimensions and then just leverage broadcasting in `forward` method.
5. `configure_optimizer` method simplifications. If traverse only in parameters and retrieve modules from parameter's name, so we don't need those comments that might confuse people.
By the way, why do we need two separate lists (whitelist and blacklist)? Since the goal is to have all parameters either in decay or no_decay the code can be further simplified:
```python
decay, no_decay = [], []
for pn, _ in self.named_parameters():
    # get the parent module by the parameter's name
    module = reduce(lambda module, key: getattr(module, key), pn.split(".")[:-1], self)
    if pn.endswith('weight') and isinstance(module, nn.Linear):
        decay.add(pn)
    else:
       no_decay.add(pn)
```
and then we don't need to check sets interaction and union.
