### PR TITLE
GPT2 dropout from huggingface is 0.1

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -46,7 +46,7 @@ if init_from == 'resume':
     model.load_state_dict(state_dict)
 elif init_from.startswith('gpt2'):
     # init from a given GPT-2 model
-    model = GPT.from_pretrained(init_from, dict(dropout=0.0))
+    model = GPT.from_pretrained(init_from, dict(dropout=0.1))
 
 model.eval()
 model.to(device)


### PR DESCRIPTION
During sampling when the model [is loaded](https://github.com/karpathy/nanoGPT/blob/master/sample.py#L49) from pretrained GPT2 weights, the dropout value is set to 0.0. I assume that was done because previously with pytorch 2.0 flash attention didn't work with dropout value that is not 0.0. From this merged [PR](https://github.com/karpathy/nanoGPT/pull/195) it seems that it is already fixed in the latest build of pytorch, so such limitation is no longer true.

If to take a look at the config of all versions of GPT2 from huggingface it appears that the dropout value for all 4 types of dropout is 0.1.

```python
from transformers import GPT2Config
dropout_set = set()
for model_size in ["gpt2", "gpt2-medium", "gpt2-large", "gpt2-xl"]:
    config = GPT2Config.get_config_dict(model_size)[0]
    dropout_set.update(
        (key, value)
        for key, value in config.items()
        if "drop" in key
    )
print(dropout_set)
>> {('attn_pdrop', 0.1),
    ('embd_pdrop', 0.1),
    ('resid_pdrop', 0.1),
    ('summary_first_dropout', 0.1)}
```

---
But there is something that I don't fully understand.
When I change value of dropout the output from sampling doesn't change. This is true for torch 1.13.1.
This kinda make sense for me (yet not fully). On inference for dropout instead of randomly zeroing out nodes we need to scale the output accordingly. Like it stated in torch [docs](https://pytorch.org/docs/stable/generated/torch.nn.Dropout.html). But this constant factor can be dropped because of normalization.

```python
import numpy as np
normalize = lambda x: (x - x.mean()) / x.std()
x = np.random.rand(10)
print(np.allclose(normalize(x), normalize(x * 0.9)))
>>> True
```
And some layers in the model are followed by LayerNorm, but some - aren't. That's why I am not 100% sure that this is the case.

So the question: if it's true, that normalization layers effectively make dropout scaling during inference not important, then do we need to set it at all (for sampling)?

---
I also tried different dropout values for sampling on Google Colab and torch==2.1.0.dev20230313+cu117 (to test flash attention).
In this case different dropout values affect sampling output.
Which makes me confused. Either my assumption is wrong (about non importance of dropout value with normalization layers), or it's something wrong with flash attention. Maybe `scaled_dot_attention` doesn't respect model's state (like train and eval) and thus works incorrectly?
At least from the [code snippet](https://pytorch.org/docs/2.0/generated/torch.nn.functional.scaled_dot_product_attention.html#torch.nn.functional.scaled_dot_product_attention) I don't see what might be an issue.