### PR TITLE
Correct number of parameters

### DIFF
--- a/scaling_laws.ipynb
+++ b/scaling_laws.ipynb
@@ -51,7 +51,7 @@
     "    \"\"\" Given GPT config calculate total number of parameters \"\"\"\n",
     "    ffw_size = 4*d_model # in GPT the number of intermediate features is always 4*d_model\n",
     "    # token and position embeddings\n",
-    "    embeddings = d_model * vocab_size + d_model * seq_len\n",
+    "    embeddings = d_model * seq_len\n",
     "    # transformer blocks\n",
     "    attention = 3*d_model**2 + 3*d_model # weights and biases\n",
     "    attproj = d_model**2 + d_model\n",


### PR DESCRIPTION
Embeddings are not included in the parameter count.

Still their calculation is wrong because of weight tying.