### PR TITLE
Fix GPT.crop_block_size when flash attention is available

### DIFF
--- a/model.py
+++ b/model.py
@@ -207,7 +207,8 @@ class GPT(nn.Module):
         self.config.block_size = block_size
         self.transformer.wpe.weight = nn.Parameter(self.transformer.wpe.weight[:block_size])
         for block in self.transformer.h:
-            block.attn.bias = block.attn.bias[:,:,:block_size,:block_size]
+            if hasattr(block.attn, 'bias'):
+                block.attn.bias = block.attn.bias[:,:,:block_size,:block_size]
 
     @classmethod
     def from_pretrained(cls, model_type, override_args=None):


### PR DESCRIPTION
`GPT.crop_block_size` fails, If flash attention is available
```
Traceback (most recent call last):
  File "/home/kirill/workspace/nanoGPT/train.py", line 181, in <module>
    model.crop_block_size(block_size)
  File "/home/kirill/workspace/nanoGPT/model.py", line 210, in crop_block_size
    block.attn.bias = block.attn.bias[:,:,:block_size,:block_size]
  File "/home/kirill/miniconda3/envs/nnexp/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1614, in __getattr__
    raise AttributeError("'{}' object has no attribute '{}'".format(
AttributeError: 'CausalSelfAttention' object has no attribute 'bias'
```
https://github.com/karpathy/nanoGPT/blob/a82b33b525ca9855d705656387698e13eb8e8d4b/model.py#L52-L58