### PR TITLE
fix "cuda out of memory" when resuming training

### DIFF
--- a/train.py
+++ b/train.py
@@ -189,6 +189,7 @@ scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
 optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)
 if init_from == 'resume':
     optimizer.load_state_dict(checkpoint['optimizer'])
+checkpoint = None # free up memory
 
 # compile the model
 if compile:


### PR DESCRIPTION
## The problem:

When training a large model that takes up almost the entire memory capacity of my GPU, I am unable to resume training from a checkpoint (despite being able to initialize and train the model from scratch), because CUDA keeps running out of memory.

After the checkpoint is loaded, `model.py` produces this error on the first forward pass of the model:
```
torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 20.00 MiB 
GPU 0; 8.00 GiB total capacity; 7.20 GiB already allocated; 0 bytes free; 7.30 GiB reserved in total by PyTorch
If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  
See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF
```

## The solution:

The cause of the problem is how the checkpoint is being loaded in `train.py` here:
https://github.com/karpathy/nanoGPT/blob/a82b33b525ca9855d705656387698e13eb8e8d4b/train.py#L152
We map `checkpoint` directly to GPU memory to initialize the model and optimizer on the GPU, but after they've been initialized, `checkpoint` is still taking up precious memory, so it's necessary to set `checkpoint = None` after we're done with all the `.load_state_dict()` calls so that python can clean up that memory.

Adding this line of code resolves the issue for me, and doesn't produce any side-effects.

## System:
GPU: Nvidia RTX 3060 Ti 8GB
OS: Windows 10
Python: 3.9.13
Cuda: 11.8
Pytorch: 2.1.0.dev20230328

## Config:
batch_size = 2
block_size = 512
n_layer = 16
n_head = 16
n_embd = 1024
device = 'cuda'
dtype = 'bfloat16'
compile = False