### PR TITLE
Windows not yet supported for torch.compile as of now

### DIFF
--- a/train.py
+++ b/train.py
@@ -71,7 +71,7 @@ backend = 'nccl' # 'nccl', 'gloo', etc.
 # system
 device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
 dtype = 'bfloat16' # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler
-compile = True # use PyTorch 2.0 to compile the model to be faster
+compile = False if os.name == 'nt' else True # use PyTorch 2.0 to compile the model to be faster, Windows not yet supported for torch.compile
 # -----------------------------------------------------------------------------
 config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
 exec(open('configurator.py').read()) # overrides from command line or config file


### PR DESCRIPTION
Set `compile` flag to `False` when running the model on Windows OS