### PR TITLE
Add stop token functionality

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -12,6 +12,7 @@ from model import GPTConfig, GPT
 init_from = 'resume' # either 'resume' (from an out_dir) or a gpt2 variant (e.g. 'gpt2-xl')
 out_dir = 'out' # ignored if init_from is not 'resume'
 start = "\n" # or "<|endoftext|>" or etc. Can also specify a file, use as: "FILE:prompt.txt"
+stop = "<end>" # "" to disable
 num_samples = 10 # number of samples to draw
 max_new_tokens = 500 # number of tokens generated in each sample
 temperature = 0.8 # 1.0 = no change, < 1.0 = less random, > 1.0 = more random, in predictions
@@ -78,12 +79,13 @@ if start.startswith('FILE:'):
     with open(start[5:], 'r', encoding='utf-8') as f:
         start = f.read()
 start_ids = encode(start)
+stop_ids = encode(stop)
 x = (torch.tensor(start_ids, dtype=torch.long, device=device)[None, ...])
 
 # run generation
 with torch.no_grad():
     with ctx:
         for k in range(num_samples):
-            y = model.generate(x, max_new_tokens, temperature=temperature, top_k=top_k)
+            y = model.generate(x, max_new_tokens, temperature=temperature, top_k=top_k, stop=stop_ids)
             print(decode(y[0].tolist()))
             print('---------------')


### PR DESCRIPTION
Small modification to `generate` function to return upon detecting an encoded stop string's token(s), along with a new global `stop` variable.

Checked with `python sample.py --init_from=gpt2 --start='This is ' --stop=. --num_samples=4 --max_new_tokens=100 --device='cuda' --dtype=float16`

(closed my erroneous previous pull request of the same nature, it can be deleted)