### PR TITLE
fix np.sum overflows on windows

### DIFF
--- a/data/openwebtext/prepare.py
+++ b/data/openwebtext/prepare.py
@@ -50,7 +50,7 @@ tokenized = split_dataset.map(
 
 # concatenate all the ids in each dataset into one large file we can use for training
 for split, dset in tokenized.items():
-    arr_len = np.sum(dset['len'])
+    arr_len = np.sum(dset['len'], dtype=np.uint64)
     filename = os.path.join(os.path.dirname(__file__), f'{split}.bin')
     dtype = np.uint16 # (can do since enc.max_token_value == 50256 is < 2**16)
     arr = np.memmap(filename, dtype=dtype, mode='w+', shape=(arr_len,))


### PR DESCRIPTION
Fixes this problem on windows: #232

Was able to reproduce on windows and fix with this.

It breaks because on windows the default value for the output of np.sum is an int32 causing overflow, while default is 64 bit on linux/mac. Same behavior with np.cumsum (the first implementation of prepare.py), so it seems like it has been overflowing from day 1 on windows, but only now people have noticed?

Tbh this just seems like stupid default behavior from numpy? Why not just force it to int64 on windows and avoid this, while letting people manually change it if needed.
