### PR TITLE
[easy] allow multithreading in load_dataset

### DIFF
--- a/data/openwebtext/prepare.py
+++ b/data/openwebtext/prepare.py
@@ -11,8 +11,13 @@ from datasets import load_dataset # huggingface datasets
 # good number to use is ~order number of cpu cores // 2
 num_proc = 8
 
+# number of workers in load_dataset() call
+# best number might be different from num_proc above as it also depends on NW speed.
+# it is better than 1 usually though
+num_proc_load_dataset = num_proc
+
 # takes 54GB in huggingface .cache dir, about 8M documents (8,013,769)
-dataset = load_dataset("openwebtext")
+dataset = load_dataset("openwebtext", num_proc=num_proc_load_dataset)
 
 # owt by default only contains the 'train' split, so create a test split
 split_dataset = dataset["train"].train_test_split(test_size=0.0005, seed=2357, shuffle=True)


### PR DESCRIPTION
Both loading from the network and generating train split can benefit from multithreading (especially on larger instances/faster network). 

On 30 CPU + single A100 lambda instance it brings down the time to get the data from ~35min (28 threads for tokenizing, 1 thread for load_dataset) to ~8min (28 threads for both).

CPU util looks like this:

28 thread load_dataset (finished): 
<img width="2557" alt="nanogpt_dataload_mt" src="https://github.com/karpathy/nanoGPT/assets/661042/1526155f-6fa7-465a-bbb1-0d6dd89d5663">

1 thread load_dataset (still running):
<img width="2556" alt="nanogpt_dataload_1T" src="https://github.com/karpathy/nanoGPT/assets/661042/d09b06f1-3065-48f7-88ac-3e20b59c2b86">


