### PR TITLE
Integration with EleutherAI/lm-evaluation-harness

### DIFF
--- a/lm_evaulation_harness.py
+++ b/lm_evaulation_harness.py
@@ -1,0 +1,94 @@
+from contextlib import nullcontext
+from typing import Iterable
+
+import torch
+
+import lm_eval
+from lm_eval.base import BaseLM
+from lm_eval.evaluator import evaluate, make_table
+
+from model import GPT
+from tokenizer import Tokenizer
+
+
+class NanoGPTModel(BaseLM):
+
+    def __init__(self, model: GPT, tokenizer: Tokenizer, device="cuda", temperature=0.8, top_k=200,
+                 max_gen_tokens=128, batch_size=1, eot_token=50256):
+        super().__init__()
+        self._model = model
+        self._tokenizer = tokenizer
+        self._device = device
+        self._max_gen_tokens = max_gen_tokens
+        self._batch_size = batch_size
+        self._eot_token = eot_token
+        self._temperature = temperature
+        self._top_k = top_k
+
+    @property
+    def eot_token_id(self):
+        return self._eot_token
+
+    @property
+    def max_length(self):
+        return self._model.config.block_size
+
+    @property
+    def max_gen_toks(self):
+        return self._max_gen_tokens
+
+    @property
+    def batch_size(self):
+        return self._batch_size
+
+    @property
+    def device(self):
+        return self._device
+
+    def tok_encode(self, string: str):
+        return self._tokenizer.encode(string)
+
+    def tok_decode(self, tokens: Iterable[int]):
+        return self._tokenizer.decode(list(tokens))
+
+    def _model_generate(self, context, max_length, eos_token_id):
+        return self._model.generate(context, max_length, temperature=self._temperature, top_k=self._top_k, eos_token=eos_token_id)
+
+    def _model_call(self, inps):
+        targets = torch.zeros_like(inps) - 1
+        return self._model(inps, targets=targets)[0]
+
+
+if __name__ == '__main__':
+    # -----------------------------------------------------------------------------
+    init_from = 'resume' # either 'resume' (from an out_dir) or a gpt2 variant (e.g. 'gpt2-xl')
+    out_dir = 'out'  # ignored if init_from is not 'resume'
+    max_new_tokens = 500  # number of tokens generated in each sample
+    temperature = 0.8  # 1.0 = no change, < 1.0 = less random, > 1.0 = more random, in predictions
+    top_k = 200  # retain only the top_k most likely tokens, clamp others to have 0 probability
+    seed = 1337
+    device = 'cuda'  # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1', etc.
+    dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16'  # 'float32' or 'bfloat16' or 'float16'
+    tasks = ["lambada_openai"]  # examples: --tasks='["lambada_openai"]'
+    exec(open('configurator.py').read())  # overrides from command line or config file
+    # -----------------------------------------------------------------------------
+
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.backends.cuda.matmul.allow_tf32 = True  # allow tf32 on matmul
+    torch.backends.cudnn.allow_tf32 = True  # allow tf32 on cudnn
+    device_type = 'cuda' if 'cuda' in device else 'cpu'  # for later use in torch.autocast
+    ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
+    ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
+
+    model, tokenizer = GPT.init_from(init_from, out_dir=out_dir, device=device)
+    model.eval()
+    model.to(device)
+
+    with torch.no_grad():
+        with ctx:
+            results = evaluate(
+                lm=NanoGPTModel(model, tokenizer, device=device, max_gen_tokens=max_new_tokens, temperature=temperature, top_k=top_k),
+                task_dict=lm_eval.tasks.get_task_dict(tasks)
+            )
+            print(make_table(results))

--- a/sample.py
+++ b/sample.py
@@ -1,12 +1,9 @@
 """
 Sample from a trained model
 """
-import os
-import pickle
 from contextlib import nullcontext
 import torch
-import tiktoken
-from model import GPTConfig, GPT
+from model import GPT
 
 # -----------------------------------------------------------------------------
 init_from = 'resume' # either 'resume' (from an out_dir) or a gpt2 variant (e.g. 'gpt2-xl')
@@ -32,52 +29,18 @@ ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torc
 ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
 
 # model
-if init_from == 'resume':
-    # init from a model saved in a specific directory
-    ckpt_path = os.path.join(out_dir, 'ckpt.pt')
-    checkpoint = torch.load(ckpt_path, map_location=device)
-    gptconf = GPTConfig(**checkpoint['model_args'])
-    model = GPT(gptconf)
-    state_dict = checkpoint['model']
-    unwanted_prefix = '_orig_mod.'
-    for k,v in list(state_dict.items()):
-        if k.startswith(unwanted_prefix):
-            state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)
-    model.load_state_dict(state_dict)
-elif init_from.startswith('gpt2'):
-    # init from a given GPT-2 model
-    model = GPT.from_pretrained(init_from, dict(dropout=0.0))
+model, tokenizer = GPT.init_from(init_from, out_dir=out_dir, device=device)
 
 model.eval()
 model.to(device)
 if compile:
     model = torch.compile(model) # requires PyTorch 2.0 (optional)
 
-# look for the meta pickle in case it is available in the dataset folder
-load_meta = False
-if init_from == 'resume' and 'config' in checkpoint and 'dataset' in checkpoint['config']: # older checkpoints might not have these...
-    meta_path = os.path.join('data', checkpoint['config']['dataset'], 'meta.pkl')
-    load_meta = os.path.exists(meta_path)
-if load_meta:
-    print(f"Loading meta from {meta_path}...")
-    with open(meta_path, 'rb') as f:
-        meta = pickle.load(f)
-    # TODO want to make this more general to arbitrary encoder/decoder schemes
-    stoi, itos = meta['stoi'], meta['itos']
-    encode = lambda s: [stoi[c] for c in s]
-    decode = lambda l: ''.join([itos[i] for i in l])
-else:
-    # ok let's assume gpt-2 encodings by default
-    print("No meta.pkl found, assuming GPT-2 encodings...")
-    enc = tiktoken.get_encoding("gpt2")
-    encode = lambda s: enc.encode(s, allowed_special={"<|endoftext|>"})
-    decode = lambda l: enc.decode(l)
-
 # encode the beginning of the prompt
 if start.startswith('FILE:'):
     with open(start[5:], 'r', encoding='utf-8') as f:
         start = f.read()
-start_ids = encode(start)
+start_ids = tokenizer.encode(start)
 x = (torch.tensor(start_ids, dtype=torch.long, device=device)[None, ...])
 
 # run generation
@@ -85,5 +48,5 @@ with torch.no_grad():
     with ctx:
         for k in range(num_samples):
             y = model.generate(x, max_new_tokens, temperature=temperature, top_k=top_k)
-            print(decode(y[0].tolist()))
+            print(tokenizer.decode(y[0].tolist()))
             print('---------------')

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -1,0 +1,47 @@
+import abc
+from abc import abstractmethod
+
+import tiktoken
+
+
+class Tokenizer(abc.ABC):
+
+    @abstractmethod
+    def encode(self, text: str) -> list[int]:
+        pass
+
+    @abstractmethod
+    def decode(self, tokens: list[int]) -> str:
+        pass
+
+
+class TiktokenTokenizer(Tokenizer):
+
+    def __init__(self, encoding: tiktoken.Encoding, allowed_special: set[str]):
+        super().__init__()
+        self._encoding = encoding
+        self._allowed_special = allowed_special
+
+    def encode(self, text: str) -> list[int]:
+        return self._encoding.encode(text, allowed_special=self._allowed_special)
+
+    def decode(self, tokens: list[int]) -> str:
+        return self._encoding.decode(tokens)
+
+    @staticmethod
+    def gpt2_tokenizer():
+        return TiktokenTokenizer(tiktoken.get_encoding("gpt2"), allowed_special={"<|endoftext|>"})
+
+
+class DictBasedTokenizer(Tokenizer):
+
+    def __init__(self, stoi: dict[str,int], itos: dict[int,str]):
+        super().__init__()
+        self._stoi = stoi
+        self._itos = itos
+
+    def encode(self, text: str) -> list[int]:
+        return [self._stoi[c] for c in text]
+
+    def decode(self, tokens: list[int]) -> str:
+        return ''.join([self._itos[i] for i in tokens])


### PR DESCRIPTION
A simple integration with https://github.com/EleutherAI/lm-evaluation-harness to be able to run i.e. LAMBADA evaluation task.

Requires `lm-eval` to be installed:
```
pip install lm-eval
```
(although I've tested against the current `master`, roughly: `1736d78`)

Can be used as follows:
```
python lm_evaulation_harness.py --init_from=gpt2 --tasks='["lambada_openai"]'
```

In my case the PPL/ACC returned by `lambada_openai` task for GPT2 models were slightly different than the one reported in GPT2 paper, but very similar (+/- the rounding error) to the PPL/ACC returned by `lm-eval` directly.

The `_model_generate(..)` is implemented, but i.e. `coqa` task rises a warning (at least using `lm-eval@master`, `v0.3.0` seems to fail with error), therefore I wouldn't rely too much on it.
The problem seems to be that `lm-eval` expects the model to be able to handle multi-token end of sequence. If someone would like to pick up from here the good place to start would probably be to check the difference between `BaseLM#greedy_until` and `HuggingFaceAutoLM#greedy_until` in terms of how `_model_generate(..)` is called, or perhaps wait since `lm-eval` seems to be working on a refactoring.
I've also only roughly checked how the `max_length()`/`max_gen_toks()`/etc. are used, so it's probably something worth to give it a second look.