### PR TITLE
nit: remove explicit ignore_index=-1

### DIFF
--- a/model.py
+++ b/model.py
@@ -184,7 +184,7 @@ class GPT(nn.Module):
         if targets is not None:
             # if we are given some desired targets also calculate the loss
             logits = self.lm_head(x)
-            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
+            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1))
         else:
             # inference-time mini-optimization: only forward the lm_head on the very last position
             logits = self.lm_head(x[:, [-1], :]) # note: using list [-1] to preserve the time dim


### PR DESCRIPTION
I believe setting `ignore_index=-1` when calling `cross_entropy` on line `187` is spurious, as:

1. ignore_index=N doesn't ignore the Nth index in the target list, it ignores any values in the target list equal to N (see: https://github.com/pytorch/pytorch/issues/18206)

2. thus, [all negative values for ignore_index do the same thing: nothing](https://stackoverflow.com/questions/69346001/pytorch-nllloss-ignore-index-default-value), because all GPT tokens are positive integers. 

3. the default value for `ignore_index` is `-100` (https://pytorch.org/docs/stable/generated/torch.nn.functional.cross_entropy.html)

Given this has generated a non-zero amount of confusion (https://github.com/karpathy/nanoGPT/issues/323, https://github.com/karpathy/nanoGPT/issues/297), and this repo is intended to be a learning resource, I think removing this would be a good choice to avoid further confusion. 

I may be missing something here, feel free to close and correct me, but I've tested training with ignore_index=-100 and it seems to work equivalently. 