### PR TITLE
Added snapshots to train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -107,7 +107,8 @@ print(f"tokens per iteration will be: {tokens_per_iter:,}")
 
 if master_process:
     os.makedirs(out_dir, exist_ok=True)
-    os.makedirs(os.path.join(out_dir, "models"), exist_ok=True)
+    if take_snapshots:
+        os.makedirs(os.path.join(out_dir, snapshot_dir), exist_ok=True)
 torch.manual_seed(1337 + seed_offset)
 torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
 torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn


### PR DESCRIPTION
Modified train.py script to make snapshots of checkpoints.

Added 4 new config values:
- take_snapshots (default = False) - if True, saves snapshots of checkpoints at specified conditions
- make_snapshots_on_checkpoint (default = False) - if True, snapshots will be taken every time checkpoint is also saved.
- snapshot_dir (default = 'snapshots') - specifies name of folder *inside* out_dir which will be used to keep snapshots in
- snapshot_interval (default = 500) - specifies per how much iterations it should take a snapshot.

Snapshots follow naming convention of: `ckpt-{iteration at time of taking snapshot}-{training loss}-{validation loss}.pt`.

I made this change because I was worried about overfitting the network, but at the same time not using "always_save_checkpoint" meant that it was possible for it to just not save after a looong time of training, which I would also not want to encounter.

Fixed: Program now makes snapshot folder, previously it only created "models" folder.