### PR TITLE
Added snapshots to train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -107,7 +107,8 @@ print(f"tokens per iteration will be: {tokens_per_iter:,}")
 
 if master_process:
     os.makedirs(out_dir, exist_ok=True)
-    os.makedirs(os.path.join(out_dir, "models"), exist_ok=True)
+    if take_snapshots:
+        os.makedirs(os.path.join(out_dir, snapshot_dir), exist_ok=True)
 torch.manual_seed(1337 + seed_offset)
 torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
 torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn

--- a/train.py
+++ b/train.py
@@ -39,7 +39,6 @@ eval_iters = 200
 eval_only = False # if True, script exits right after the first eval
 always_save_checkpoint = True # if True, always save a checkpoint after each eval
 take_snapshots = False # if True, saves checkpoint snapshots to folder specified in snapshot_dir
-make_snapshots_on_checkpoint = False
 snapshot_dir = 'snapshots' # specifies folder *inside* out_dir to save snapshots to
 snapshot_interval = 500
 init_from = 'scratch' # 'scratch' or 'resume' or 'gpt2*'
@@ -288,7 +287,7 @@ while True:
                 }
                 print(f"saving checkpoint to {out_dir}")
                 torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
-        if ((iter_num - last_saved) >= snapshot_interval) or (make_snapshots_on_checkpoint and (losses['val'] < best_val_loss or always_save_checkpoint)) and take_snapshots:
+        if (iter_num - last_saved) >= snapshot_interval and take_snapshots:
             print(f"saving snapshot to {snapshot_dir}")
             torch.save(checkpoint, os.path.join(out_dir, snapshot_dir, f"ckpt-{iter_num}-{losses['train']:.4f}-{losses['val']:.4f}.pt"))
             last_saved = iter_num


### PR DESCRIPTION
Modified train.py script to make snapshots of checkpoints.

Added 4 new config values:
- take_snapshots (default = False) - if True, saves snapshots of checkpoints at specified conditions
- snapshot_dir (default = 'snapshots') - specifies name of folder *inside* out_dir which will be used to keep snapshots in
- snapshot_interval (default = 500) - specifies per how much iterations it should take a snapshot. It is connected with checkpoint code, which means it won't save snapshot every time this number of iterations happens, but rather diring checkpoint save after passing that amount of iterations, when set to 0 will save a snapshot on every checkpoint save

Snapshots follow naming convention of: `ckpt-{iteration at time of taking snapshot}-{training loss}-{validation loss}.pt`.

I made this change because I was worried about overfitting the network, but at the same time not using "always_save_checkpoint" meant that it was possible for it to just not save after a looong time of training, which I would also not want to encounter.

This is last PR for now I promise.