### PR TITLE
add a barrier after eval in DDP

### DIFF
--- a/train.py
+++ b/train.py
@@ -257,10 +257,10 @@ while True:
         param_group['lr'] = lr
 
     # evaluate the loss on train/val sets and write checkpoints
-    if iter_num % eval_interval == 0 and master_process:
+    if iter_num % eval_interval == 0:
         losses = estimate_loss()
         print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
-        if wandb_log:
+        if wandb_log and master_process:
             wandb.log({
                 "iter": iter_num,
                 "train/loss": losses['train'],
@@ -268,7 +268,7 @@ while True:
                 "lr": lr,
                 "mfu": running_mfu*100, # convert to percentage
             })
-        if losses['val'] < best_val_loss or always_save_checkpoint:
+        if (losses['val'] < best_val_loss or always_save_checkpoint) and master_process:
             best_val_loss = losses['val']
             if iter_num > 0:
                 checkpoint = {


### PR DESCRIPTION
In the original implementation, only GPU0 is doing the eval and the others will need to wait.

This PR adds eval on all GPUs and a barrier after the eval to ensure all GPUs are ready when the training starts. This can prevent GPUs from running out of memory.

Ideally, the eval part would also be ported to fully support DDP (average the scores from each GPU).