### PR TITLE
the '=' is unuseable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ pip install torch numpy transformers datasets tiktoken wandb tqdm
 
 Dependencies:
 
-- [pytorch](https://pytorch.org) <3
-- [numpy](https://numpy.org/install/) <3
--  `transformers` for huggingface transformers <3 (to load GPT-2 checkpoints)
--  `datasets` for huggingface datasets <3 (if you want to download + preprocess OpenWebText)
--  `tiktoken` for OpenAI's fast BPE code <3
--  `wandb` for optional logging <3
--  `tqdm` for progress bars <3
+- [pytorch](https://pytorch.org)
+- [numpy](https://numpy.org/install/)
+-  `transformers` for huggingface transformers (to load GPT-2 checkpoints)
+-  `datasets` for huggingface datasets (if you want to download + preprocess OpenWebText)
+-  `tiktoken` for OpenAI's fast BPE code
+-  `wandb` for optional logging
+-  `tqdm` for progress bars
 
 ## quick start
 

--- a/configurator.py
+++ b/configurator.py
@@ -29,7 +29,7 @@ for arg in sys.argv[1:]:
     else:
         # assume it's a --key=value argument
         assert arg.startswith('--')
-        key, val = arg.split('=')
+        key, val = arg.split('=', maxsplit=1)
         key = key[2:]
         if key in globals():
             try:


### PR DESCRIPTION
Due to the code inside of configurator.py, as the '=' char did not have a max split, the '=' was absolutely unuseable, instantly breaking down. this code adds a max split, allowing for the '=' to be used.