### PR TITLE
Flash attention 2.0

### DIFF
--- a/model.py
+++ b/model.py
@@ -15,8 +15,6 @@ import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
-from flash_attn import flash_attn_qkvpacked_func
-
 class LayerNorm(nn.Module):
     """ LayerNorm but with an optional bias. PyTorch doesn't support simply bias=False """
 
@@ -60,6 +58,7 @@ class CausalSelfAttention(nn.Module):
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
         if self.flash2:
             # efficient attention using Flash Attention CUDA kernels
+            from flash_attn import flash_attn_qkvpacked_func
             y = flash_attn_qkvpacked_func(qkv, dropout_p=self.dropout if self.training else 0, causal=True)
             # y: (B, T, nh, hs).
         else:


### PR DESCRIPTION
Requires installing flash attention 2.0 from https://github.com/Dao-AILab/flash-attention if flash2 = True.  Gives a small speedup on my 3080 (which is not the ideal GPU to run this on, would be interested to see A100 numbers).  Note that the packed qkv from flash attention 2 was significantly faster here.

```
Baseline with batch_size = 64, compile = True, flash = True
iter 4110: loss 0.8675, time 48.25ms, mfu 7.48% 

batch 64, compile = False, flash # compiling actually worse on 3080!
iter 130: loss 2.4168, time 43.72ms, mfu 8.59%

batch 64, compile = False, flash2
iter 200: loss 2.2111, time 41.44ms, mfu 9.02%
```