### PR TITLE
Cleaner & more verbose & colored output on console

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -22,7 +22,7 @@ for arg in sys.argv[1:]:
         # assume it's the name of a config file
         assert not arg.startswith('--')
         config_file = arg
-        print(f"Overriding config with {config_file}:")
+        print("\x1b[43m" "\x1b[30m" f"Overriding config with {config_file}:" "\x1b[0m")
         with open(config_file) as f:
             print(f.read())
         exec(open(config_file).read())

--- a/train.py
+++ b/train.py
@@ -288,7 +288,7 @@ while True:
             f"{ansi['blue']}step{ansi['reset']} {iter_num:{max(4, len(str(max_iters)))}}:",
             f"{ansi['blue']}train loss{ansi['reset']} {losses['train']:.4f},",
             f"{ansi['blue']}val loss{ansi['reset']} {ansi['green' if losses['val'] < best_val_loss else 'red']}{losses['val']:.4f}{ansi['reset']},",
-            f"Δt {datetime.fromtimestamp(t1_el) - datetime.fromtimestamp(t0_el)}",
+            f"{ansi['blue']}Δt{ansi['reset']} {datetime.fromtimestamp(t1_el) - datetime.fromtimestamp(t0_el)}",
             end = " ")
         if wandb_log:
             wandb.log({


### PR DESCRIPTION
This PR adds improvements regarding the output on the console during training.

- [x] Cleaner output
  - [x] Align columns
  - [x] remove duplicate information from `log_interval` output and move it to a header line (printed after each `eval_interval`)
- [x] More verbose output
  - [x] Add print statements to indicate when training starts (yellow highlighted headers)
  - [x] Add progress indicator for `estimate_loss()`
- [x] Colored output
  - [x] Highlight sections & keywords
  - [x] For each iter `loss` & `mfu` are green if better than previous value (else red)
  - [x] For each evaluation step print `val loss` green if better then `best_val_loss` (else red)

![nanoGPT-cast-opt](https://github.com/karpathy/nanoGPT/assets/20573323/27ad5d80-4ed5-40a1-beb0-d680bee442f2)
