### PR TITLE
Fix BUG when `=` in CLI value, like: --start="1+1="

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -29,8 +29,7 @@ for arg in sys.argv[1:]:
     else:
         # assume it's a --key=value argument
         assert arg.startswith('--')
-        key, val = arg.split('=')
-        key = key[2:]
+        key, val = arg[2:arg.index('=')], arg[arg.index('=') + 1:]
         if key in globals():
             try:
                 # attempt to eval it it (e.g. if bool, number, or etc)


### PR DESCRIPTION
```
$ python sample.py --out_dir=out --start="1 + 1="

Overriding: out_dir = out
Traceback (most recent call last):
  File "sample.py", line 23, in <module>
    exec(open('configurator.py').read()) # overrides from command line or config file
  File "<string>", line 32, in <module>
ValueError: too many values to unpack (expected 2)
```