### PR TITLE
Generalize encode/decode for datasets 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ __pycache__/
 *.pt
 *.pyc
 input.txt
+*.venv
+*.code-workspace
+out/
+out-*/
+wandb/*
+data/*/samples/*

--- a/data/shakespeare_char/prepare.py
+++ b/data/shakespeare_char/prepare.py
@@ -5,7 +5,7 @@ Will save train.bin, val.bin containing the ids, and meta.pkl containing the
 encoder and decoder and some other related info.
 """
 import os
-import pickle
+import dill
 import requests
 import numpy as np
 
@@ -54,11 +54,11 @@ val_ids.tofile(os.path.join(os.path.dirname(__file__), 'val.bin'))
 # save the meta information as well, to help us encode/decode later
 meta = {
     'vocab_size': vocab_size,
-    'itos': itos,
-    'stoi': stoi,
+    'encode': encode,
+    'decode': decode,
 }
 with open(os.path.join(os.path.dirname(__file__), 'meta.pkl'), 'wb') as f:
-    pickle.dump(meta, f)
+    dill.dump(meta, f, recurse=True)
 
 # length of dataset in characters:  1115394
 # all the unique characters:

--- a/sample.py
+++ b/sample.py
@@ -2,7 +2,7 @@
 Sample from a trained model
 """
 import os
-import pickle
+import dill
 from contextlib import nullcontext
 import torch
 import tiktoken
@@ -61,11 +61,8 @@ if init_from == 'resume' and 'config' in checkpoint and 'dataset' in checkpoint[
 if load_meta:
     print(f"Loading meta from {meta_path}...")
     with open(meta_path, 'rb') as f:
-        meta = pickle.load(f)
-    # TODO want to make this more general to arbitrary encoder/decoder schemes
-    stoi, itos = meta['stoi'], meta['itos']
-    encode = lambda s: [stoi[c] for c in s]
-    decode = lambda l: ''.join([itos[i] for i in l])
+        meta = dill.load(f)
+    encode, decode = meta['encode'], meta['decode']
 else:
     # ok let's assume gpt-2 encodings by default
     print("No meta.pkl found, assuming GPT-2 encodings...")

--- a/train.py
+++ b/train.py
@@ -19,7 +19,7 @@ $ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123
 import os
 import time
 import math
-import pickle
+import dill
 from contextlib import nullcontext
 
 import numpy as np
@@ -136,7 +136,7 @@ meta_path = os.path.join(data_dir, 'meta.pkl')
 meta_vocab_size = None
 if os.path.exists(meta_path):
     with open(meta_path, 'rb') as f:
-        meta = pickle.load(f)
+        meta = dill.load(f)
     meta_vocab_size = meta['vocab_size']
     print(f"found vocab_size = {meta_vocab_size} (inside {meta_path})")
 


### PR DESCRIPTION
This fixes a TODO to allow arbitrary encoding/decoding schemes for
different datasets. To do so, I switched from pickle to dill, which
extends pickle to enable things like pickling functions, including
their referenced globals. dill is already a dependency of datasets,
so this doesn't add any new dependencies.

This PR also includes some gitignore additions that I found
necessary for my usage. I can alter the entries, remove it from this
PR, or break it into a separate PR, as you prefer. Probably the most
controversial addition would be `data/*/samples/*`, since that's not
a format that is currently referenced in this codebase. I was using
directories like that to save sample prompts for datasets. Happy to
drop it if its inclusion is not desired.