### PR TITLE
fixes divide by zero in mfu

### DIFF
--- a/train.py
+++ b/train.py
@@ -319,7 +319,7 @@ while True:
         # scale up to undo the division above, approximating the true total loss (exact would have been a sum)
         lossf = loss.item() * gradient_accumulation_steps
         if local_iter_num >= 5: # let the training loop settle a bit
-            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)
+            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt+0.0001)
             running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu
         print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
     iter_num += 1


### PR DESCRIPTION
Other wise I get a divide by zero error in function estimate_mfu at line 300 when you divide by dt. Tested on a RTX 4090 on windows.