### PR TITLE
Open "shakespeare" data in UTF-8 in "prepare.py"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 *.pt
 *.pyc
 input.txt
+env/
+venv/

--- a/data/shakespeare/prepare.py
+++ b/data/shakespeare/prepare.py
@@ -7,10 +7,10 @@ import numpy as np
 input_file_path = os.path.join(os.path.dirname(__file__), 'input.txt')
 if not os.path.exists(input_file_path):
     data_url = 'https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt'
-    with open(input_file_path, 'w') as f:
+    with open(input_file_path, 'w', encoding='utf-8') as f:
         f.write(requests.get(data_url).text)
 
-with open(input_file_path, 'r') as f:
+with open(input_file_path, 'r', encoding='utf-8') as f:
     data = f.read()
 n = len(data)
 train_data = data[:int(n*0.9)]


### PR DESCRIPTION
`open()` function in Python does not support UTF-8 encoding by default in Windows. In this case there might be some unexpected results while using non-ASCII characters. 