### PR TITLE
Refactor for easier configuration and overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Dependencies:
 -  `wandb` for optional logging <3
 -  `tqdm` for progress bars <3
 
+## Details of Changes
+-   refactored configurator.py to load a yaml configuration
+-   still able to override configuration with --key=value
+-   new dotdic.py file to allow for dot notation of dictionary attributes
+-   get configuration from configurator and load dotdict as dd
+-   assign configuration parameters using dot notation
+
+To run the default configuration: python train.py
+To run a different configuration: ENV=cpu python train.py
+
 ## quick start
 
 If you are not a deep learning professional and you just want to feel the magic and get your feet wet, the fastest way to get started is to train a character-level GPT on the works of Shakespeare. First, we download it as a single (1MB) file and turn it from raw text into one large stream of integers:

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,70 @@
+default: &default # Lets you use the same config file with different defaults
+  # Default config values for nanoGPT
+  # -----------------------------------------------------------------------------
+  # I/O
+  out_dir: 'out'
+  eval_interval: 2000
+  log_interval: 1
+  eval_iters: 20
+  eval_only: False # if True, script exits right after the first eval
+  always_save_checkpoint: True # if True, always save a checkpoint after each eval
+  init_from: 'scratch' # 'scratch' or 'resume' or 'gpt2*'
+  # -----------------------------------------------------------------------------
+  # wandb
+  wandb: False
+  wandb_project: 'owt'
+  wandb_run_name: 'gpt2'
+  # -----------------------------------------------------------------------------
+  # data
+  # Dataset based on OpenWebText but refactored to be more manageable
+  dataset: 'openwebtext' 
+  gradient_accumulation_steps: 40 # originally 5 * 8 but yaml can't handle it needs to an integer
+  batch_size: 12 # if gradient_accumulation_steps > 1, this is the micro-batch size
+  block_size: 1024
+  # -----------------------------------------------------------------------------
+  # model
+  n_layer: 12
+  n_head: 12
+  n_embd: 764
+  dropout: 0.0 # for pretraining 0 is good, for finetuning try 0.1+
+  bias: False # do we use bias inside LayerNorm and Linear layers?
+  # -----------------------------------------------------------------------------
+  # adamw optimizer
+  # We use the !!!float yaml tag to force the yaml parser to read the value as a float
+  learning_rate: !!float 6e-4 # max learning rate
+  max_iters: 60000 # total number of training iterations
+  weight_decay: !!float 1e-1
+  beta1: 0.9
+  beta2: 0.95
+  grad_clip: 1.0 # clip gradients at this value, or disable if:= 0.0
+  # -----------------------------------------------------------------------------
+  # learning rate decay settings
+  decay_lr: True # whether to decay the learning rate
+  warmup_iters: 2000 # how many steps to warm up for
+  lr_decay_iters: 60000 # should be ~= max_iters per Chinchilla
+  min_lr: !!float 6e-5 # minimum learning rate, should be ~= learning_rate/10 per Chinchilla
+  # -----------------------------------------------------------------------------
+  # DDP settings
+  backend: 'nccl' # 'nccl', 'gloo', etc.
+  # -----------------------------------------------------------------------------
+  # system
+  device: 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
+  dtype: 'bfloat16' # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler
+  compile: True # use PyTorch 2.0 to compile the model to be faster
+  # -----------------------------------------------------------------------------
+
+# Cpu config
+cpu: &cpu # Lets you use the same config file with different defaults
+  <<: *default # use the same config as default
+  eval_iters: 20
+  # My cpu config for nanoGPT
+  # Default block size is to large for cpu training so we need to reduce it
+  block_size: 128 # Adjust this if you are running out of memory or want to increase block size
+  n_layer: 4
+  n_head: 4
+  n_embd: 128
+  max_iters: 2000
+  lr_decay_iters: 2000
+  backend: 'gloo' # Backend for CPU training
+  device: 'cpu' # Change to 'cpu' if you don't have a GPU
+  compile: False

--- a/dotdict.py
+++ b/dotdict.py
@@ -1,0 +1,5 @@
+class dotdict(dict):
+    """dot.notation access to dictionary attributes"""
+    __getattr__ = dict.get
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__

--- a/train.py
+++ b/train.py
@@ -29,49 +29,63 @@ from torch.distributed import init_process_group, destroy_process_group
 
 from model import GPTConfig, GPT
 
+from configurator import config
+from dotdict import dotdict as dd # alias for dotdict for convenience
+
+
+# Extract the configuration for the specified environment
+# The default is 'default' in config.yaml
+# Use dot notation to access the values
+config = dd(config)
 # -----------------------------------------------------------------------------
-# default config values designed to train a gpt2 (124M) on OpenWebText
 # I/O
-out_dir = 'out'
-eval_interval = 2000
-log_interval = 1
-eval_iters = 200
-eval_only = False # if True, script exits right after the first eval
-always_save_checkpoint = True # if True, always save a checkpoint after each eval
-init_from = 'scratch' # 'scratch' or 'resume' or 'gpt2*'
+out_dir = config.out_dir
+eval_interval = config.eval_interval
+log_interval = config.log_interval
+eval_iters = config.eval_iters
+eval_only = config.eval_only 
+always_save_checkpoint = config.always_save_checkpoint 
+init_from = config.init_from 
+# -----------------------------------------------------------------------------
 # wandb logging
-wandb_log = False # disabled by default
-wandb_project = 'owt'
-wandb_run_name = 'gpt2' # 'run' + str(time.time())
+wandb_log = config.wandb
+wandb_project = config.wandb_project
+wandb_run_name = config.wandb_run_name
+# -----------------------------------------------------------------------------
 # data
-dataset = 'openwebtext'
-gradient_accumulation_steps = 5 * 8 # used to simulate larger batch sizes
-batch_size = 12 # if gradient_accumulation_steps > 1, this is the micro-batch size
-block_size = 1024
+dataset = config.dataset
+gradient_accumulation_steps = int(config.gradient_accumulation_steps)
+batch_size = config.batch_size
+block_size = config.block_size
+# -----------------------------------------------------------------------------
 # model
-n_layer = 12
-n_head = 12
-n_embd = 768
-dropout = 0.0 # for pretraining 0 is good, for finetuning try 0.1+
-bias = False # do we use bias inside LayerNorm and Linear layers?
+n_layer = config.n_layer
+n_head = config.n_head
+n_embd = config.n_embd
+dropout = config.dropout
+bias = config.bias
+# -----------------------------------------------------------------------------
 # adamw optimizer
-learning_rate = 6e-4 # max learning rate
-max_iters = 600000 # total number of training iterations
-weight_decay = 1e-1
-beta1 = 0.9
-beta2 = 0.95
-grad_clip = 1.0 # clip gradients at this value, or disable if == 0.0
+learning_rate = float(config.learning_rate)
+max_iters = config.max_iters
+weight_decay = config.weight_decay
+beta1 = config.beta1
+beta2 = config.beta2
+grad_clip = config.grad_clip
+# -----------------------------------------------------------------------------
 # learning rate decay settings
-decay_lr = True # whether to decay the learning rate
-warmup_iters = 2000 # how many steps to warm up for
-lr_decay_iters = 600000 # should be ~= max_iters per Chinchilla
-min_lr = 6e-5 # minimum learning rate, should be ~= learning_rate/10 per Chinchilla
+decay_lr = config.decay_lr
+warmup_iters = config.warmup_iters
+lr_decay_iters = config.lr_decay_iters
+min_lr = config.min_lr
+# -----------------------------------------------------------------------------
 # DDP settings
-backend = 'nccl' # 'nccl', 'gloo', etc.
+backend = config.backend
+# -----------------------------------------------------------------------------
 # system
-device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
-dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler
-compile = True # use PyTorch 2.0 to compile the model to be faster
+device = config.device
+dtype = config.dtype if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' 
+compile = config.compile
 # -----------------------------------------------------------------------------
 config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
 exec(open('configurator.py').read()) # overrides from command line or config file


### PR DESCRIPTION
## Details of Changes
-   refactored configurator.py to load a yaml configuration
-   still able to override configuration with --key=value
-   new dotdic.py file to allow for dot notation of dictionary attributes
-   get configuration from configurator and load dotdict as dd
-   assign configuration parameters using dot notation

To run the default configuration: python train.py
To run a different configuration: ENV=cpu python train.py