### PR TITLE
fix: h100-mfu-calculation

### DIFF
--- a/model.py
+++ b/model.py
@@ -298,7 +298,7 @@ class GPT(nn.Module):
         flops_per_iter = flops_per_fwdbwd * fwdbwd_per_iter
         # express our flops throughput as ratio of A100 bfloat16 peak flops
         flops_achieved = flops_per_iter * (1.0/dt) # per second
-        if torch.cuda.get_device_name() == 'NVIDIA H100 80GB HBM3:
+        if torch.cuda.get_device_name() == 'NVIDIA H100 80GB HBM3':
             flops_promised = 989e12 # H100 GPU bfloat16 peak flops is 989 TFLOPs
         else:
             flops_promised = 312e12 # A100 GPU bfloat16 peak flops is 312 TFLOPS

--- a/model.py
+++ b/model.py
@@ -298,7 +298,10 @@ class GPT(nn.Module):
         flops_per_iter = flops_per_fwdbwd * fwdbwd_per_iter
         # express our flops throughput as ratio of A100 bfloat16 peak flops
         flops_achieved = flops_per_iter * (1.0/dt) # per second
-        flops_promised = 312e12 # A100 GPU bfloat16 peak flops is 312 TFLOPS
+        if torch.cuda.get_device_name() == 'NVIDIA H100 80GB HBM3:
+            flops_promised = 989e12 # H100 GPU bfloat16 peak flops is 989 TFLOPs
+        else:
+            flops_promised = 312e12 # A100 GPU bfloat16 peak flops is 312 TFLOPS
         mfu = flops_achieved / flops_promised
         return mfu
 


### PR DESCRIPTION
I was getting 104% MFU on h100 then i realized that MFU calculation might of been based on a100 312 tflops 

h100 is 989 tflops at bfloat16. nvidia claims 1,979tflops but that is for 2:4 sparsity.

<img width="515" alt="image" src="https://github.com/karpathy/nanoGPT/assets/47992694/7ed83ae5-3769-4c48-91a6-7cc4d8f6e140">
