### PR TITLE
fix(train.py): mfu estimation to respect CPU-GPU sync point

### DIFF
--- a/train.py
+++ b/train.py
@@ -314,15 +314,15 @@ while True:
     optimizer.zero_grad(set_to_none=True)
 
     # timing and logging
-    t1 = time.time()
-    dt = t1 - t0
-    t0 = t1
     if iter_num % log_interval == 0 and master_process:
         # get loss as float. note: this is a CPU-GPU sync point
         # scale up to undo the division above, approximating the true total loss (exact would have been a sum)
         lossf = loss.item() * gradient_accumulation_steps
+        t1 = time.time()
+        dt = t1 - t0
+        t0 = t1
         if local_iter_num >= 5: # let the training loop settle a bit
-            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)
+            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps * log_interval, dt)
             running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu
         print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
     iter_num += 1


### PR DESCRIPTION
Previously, the mfu timing measurement was taken before the CPU-GPU sync point at every iter. The resulting `running_mfu`:
- would converge correctly when `log_interval = 1`.
- could converge to > 100% when `log_interval > 1`.

See diagrams below.

### `log_interval` = 1
![mfu drawio](https://github.com/karpathy/nanoGPT/assets/21175652/ee5a3381-ea99-418f-b684-54f3c96875c6)

### `log_interval` = 2
Note that `t3 - t2` is discarded. Only `t2 - t1` and `t4 - t3` etc contribute to `running_mfu`.
![mfu2 drawio](https://github.com/karpathy/nanoGPT/assets/21175652/eba140e4-28d1-41f8-8796-4fafc57e1442)
