### PR TITLE
fix val dataset size code comment

### DIFF
--- a/data/openwebtext/prepare.py
+++ b/data/openwebtext/prepare.py
@@ -73,7 +73,7 @@ if __name__ == '__main__':
             idx += len(arr_batch)
         arr.flush()
 
-    # train.bin is ~17GB, val.bin ~8.5MB
+    # train.bin is ~17GB, val.bin ~85MB
     # train has ~9B tokens (9,035,582,198)
     # val has ~4M tokens (4,434,897)
 


### PR DESCRIPTION
The current code comment is `8.5MB`, but it should be `85MB`:

<img width="265" alt="image" src="https://github.com/karpathy/nanoGPT/assets/603426/977ecef1-59ef-4d7a-8a96-e914f0b14e43">

Just doing god's work