### PR TITLE
free up state_dict variable memory after loading checkpoint

### DIFF
--- a/train.py
+++ b/train.py
@@ -176,6 +176,7 @@ elif init_from == 'resume':
         if k.startswith(unwanted_prefix):
             state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)
     model.load_state_dict(state_dict)
+    state_dict = None # free up memory
     iter_num = checkpoint['iter_num']
     best_val_loss = checkpoint['best_val_loss']
 elif init_from.startswith('gpt2'):


### PR DESCRIPTION
This PR frees up memory used by the `state_dict` variable after we are done using it to load a checkpoint. Not freeing this variable uses up a lot of unnecessary memory on GPUs.