### PR TITLE
Adding NVIDIA hardware performance detection

### DIFF
--- a/model.py
+++ b/model.py
@@ -286,7 +286,7 @@ class GPT(nn.Module):
 
         return optimizer
 
-    def estimate_mfu(self, fwdbwd_per_iter, dt):
+    def estimate_mfu(self, fwdbwd_per_iter, dt, flops_promised):
         """ estimate model flops utilization (MFU) in units of A100 bfloat16 peak FLOPS """
         # first estimate the number of flops we do per iteration.
         # see PaLM paper Appendix B as ref: https://arxiv.org/abs/2204.02311
@@ -298,7 +298,6 @@ class GPT(nn.Module):
         flops_per_iter = flops_per_fwdbwd * fwdbwd_per_iter
         # express our flops throughput as ratio of A100 bfloat16 peak flops
         flops_achieved = flops_per_iter * (1.0/dt) # per second
-        flops_promised = 312e12 # A100 GPU bfloat16 peak flops is 312 TFLOPS
         mfu = flops_achieved / flops_promised
         return mfu
 

--- a/train.py
+++ b/train.py
@@ -34,7 +34,7 @@ from model import GPTConfig, GPT
 
 def get_nvidia_gpu_performance():
     performance_map = {
-        "H100": 1979e12,  # 1979 TFLOPS
+        "H100": 989e12,  # 989 TFLOPS
         "A100": 312e12    # 312 TFLOPS
     }
     try:


### PR DESCRIPTION
Currently, only A100 TF32 max FLOPs performance was hardcoded in MFU calculations. 

Add: 
- Function to detect hardware (either H100 or A100) and calculate max TF32 performance 

Changed:
- Training loop to print MFU only when hardware detection is correct