### PR TITLE
fix: ensure non-zero learning rate during warmup at iteration 0

### DIFF
--- a/train.py
+++ b/train.py
@@ -231,7 +231,7 @@ def estimate_loss():
 def get_lr(it):
     # 1) linear warmup for warmup_iters steps
     if it < warmup_iters:
-        return learning_rate * it / warmup_iters
+        return learning_rate * (it + 1) / (warmup_iters + 1)
     # 2) if it > lr_decay_iters, return min learning rate
     if it > lr_decay_iters:
         return min_lr


### PR DESCRIPTION
# Fix Zero Learning Rate Issue During Warmup

Fixes issue #443 where the learning rate becomes zero at iteration 0 during warmup.

## Changes
- Modified warmup calculation in get_lr() to prevent zero learning rate while maintaining linear warmup behavior
- Uses (it + 1)/(warmup_iters + 1) instead of it/warmup_iters

## Testing & Verification
Thoroughly tested the learning rate calculation across multiple iteration values:
```
iter_num | old_lr    | new_lr
------------------------------
       0 | 0.00e+00 | 3.00e-07  # Now starts at non-zero LR
       1 | 3.00e-07 | 6.00e-07  # Maintains linear scaling
      10 | 3.00e-06 | 3.30e-06
     100 | 3.00e-05 | 3.03e-05
    1000 | 3.00e-04 | 3.00e-04
    2000 | 6.00e-04 | 6.00e-04  # Reaches same max LR
```

Testing confirms:
1. Non-zero initial learning rate at iteration 0
2. Linear scaling maintained throughout warmup
3. Smooth transition with no discontinuities
4. Same maximum learning rate (6e-4) reached at warmup completion

Created with help from Devin: https://app.devin.ai/sessions/9e0c3255385c463f838f5b2f4413b92f