### PR TITLE
fix: Add trust_remote_code=True to openwebtext loading for compatibility with latest datasets library

### DIFF
--- a/data/openwebtext/prepare.py
+++ b/data/openwebtext/prepare.py
@@ -20,7 +20,7 @@ enc = tiktoken.get_encoding("gpt2")
 
 if __name__ == '__main__':
     # takes 54GB in huggingface .cache dir, about 8M documents (8,013,769)
-    dataset = load_dataset("openwebtext", num_proc=num_proc_load_dataset)
+    dataset = load_dataset("openwebtext", num_proc=num_proc_load_dataset, trust_remote_code=True)
 
     # owt by default only contains the 'train' split, so create a test split
     split_dataset = dataset["train"].train_test_split(test_size=0.0005, seed=2357, shuffle=True)


### PR DESCRIPTION
Recent versions of the Hugging Face `datasets` library require the argument `trust_remote_code=True` when loading some datasets, including `openwebtext`, due to security changes. Without this argument, users encounter the following error:

```
ValueError: The repository for openwebtext contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/openwebtext.
Please pass the argument `trust_remote_code=True` to allow custom code to be run. 
```

This update adds `trust_remote_code=True` to the `load_dataset` call in prepare.py:

```python
dataset = load_dataset("openwebtext", num_proc=num_proc_load_dataset, trust_remote_code=True)
```

This change is necessary for compatibility with the latest `datasets` library and ensures that new users can successfully prepare the OpenWebText dataset without encountering errors. No other code changes are made.