### PR TITLE
Improve MFU Calculation

### DIFF
--- a/train.py
+++ b/train.py
@@ -322,7 +322,7 @@ while True:
         # scale up to undo the division above, approximating the true total loss (exact would have been a sum)
         lossf = loss.item() * gradient_accumulation_steps
         if local_iter_num >= 5: # let the training loop settle a bit
-            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)
+            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps * ddp_world_size, dt)
             running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu
         print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
     iter_num += 1

--- a/train.py
+++ b/train.py
@@ -322,7 +322,7 @@ while True:
         # scale up to undo the division above, approximating the true total loss (exact would have been a sum)
         lossf = loss.item() * gradient_accumulation_steps
         if local_iter_num >= 5: # let the training loop settle a bit
-            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps * ddp_world_size, dt)
+            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps * ddp_world_size, dt, dtype=dtype) # account for the scaled gradient accumulation reduction with DDP, if needed
             running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu
         print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
     iter_num += 1


### PR DESCRIPTION
Currently, MFU calculation doesn't account for the updated grad accum reduction when DDP is being used, so the actual FLOPs being passed to MFU will be `model_FLOPs / ddp_world_size`, so the resulting MFU will decrease linearly with ddp_world_size. 

While I was at it, I added a lookup table of common accelerators to their peak tflops at the dtypes supported in upstream nanoGPT, along with their automatic detection. 

Let me know if you'd like any changes!