### PR TITLE
feat: implement ALiBi (Attention with Linear Biases) for length extra…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,227 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+nanoGPT is a minimalist GPT training framework designed for simplicity and hackability. It reproduces GPT-2 results while maintaining readable code (~300 lines each for training and model definition).
+
+## Architecture
+
+### Core Components
+- **train.py**: Main training loop with distributed training support
+- **model.py**: GPT model implementation with transformer architecture
+- **sample.py**: Text generation/inference from trained models
+- **configurator.py**: Configuration management system
+- **config/**: Configuration files for different training scenarios
+
+### Key Files
+- `model.py:GPT` - Main GPT model class
+- `model.py:CausalSelfAttention` - Multi-head attention implementation
+- `train.py:train()` - Core training loop (around line 200+)
+- `sample.py:generate()` - Text generation function
+
+## Common Commands
+
+### Installation
+```bash
+pip install torch numpy transformers datasets tiktoken wandb tqdm
+```
+
+### Quick Start (Shakespeare Character-level)
+```bash
+# Prepare data
+python data/shakespeare_char/prepare.py
+
+# Train model
+python train.py config/train_shakespeare_char.py
+
+# Generate samples
+python sample.py --out_dir=out-shakespeare-char
+```
+
+### GPT-2 Reproduction
+```bash
+# Prepare OpenWebText data
+python data/openwebtext/prepare.py
+
+# Train GPT-2 (124M) on 8 GPUs
+torchrun --standalone --nproc_per_node=8 train.py config/train_gpt2.py
+```
+
+### Evaluation
+```bash
+# Evaluate pre-trained GPT-2 models
+python train.py config/eval_gpt2.py
+python train.py config/eval_gpt2_medium.py
+python train.py config/eval_gpt2_large.py
+python train.py config/eval_gpt2_xl.py
+```
+
+### Finetuning
+```bash
+# Finetune GPT-2 on Shakespeare
+python train.py config/finetune_shakespeare.py
+```
+
+### Sampling from Pre-trained Models
+```bash
+# Sample from GPT-2 XL
+python sample.py --init_from=gpt2-xl --start="Your prompt here" --num_samples=5 --max_new_tokens=100
+```
+
+### Benchmarking
+```bash
+# Profile training performance
+python bench.py
+```
+
+## Configuration System
+
+Configuration is handled through Python files in the `config/` directory. Key parameters:
+- `batch_size`: Micro-batch size per GPU
+- `gradient_accumulation_steps`: Simulates larger batch sizes
+- `block_size`: Context length (sequence length)
+- `n_layer`, `n_head`, `n_embd`: Model architecture parameters
+- `learning_rate`, `max_iters`, `lr_decay_iters`: Training hyperparameters
+- `init_from`: 'scratch', 'resume', or 'gpt2*' for initialization
+- `use_alibi`: True/False - Enable ALiBi (Attention with Linear Biases) for length extrapolation
+
+## Distributed Training
+
+### Single GPU
+```bash
+python train.py --batch_size=32 --compile=False
+```
+
+### Multi-GPU (Single Node)
+```bash
+torchrun --standalone --nproc_per_node=4 train.py
+```
+
+### Multi-Node
+```bash
+# Master node
+torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 --master_addr=IP --master_port=1234 train.py
+
+# Worker node
+torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=IP --master_port=1234 train.py
+```
+
+## Data Preparation
+
+### Shakespeare Character-level
+- Uses character-level tokenization
+- Creates `train.bin` and `val.bin` files
+- Fast setup for experimentation
+
+### OpenWebText
+- Uses GPT-2 BPE tokenization via tiktoken
+- Large dataset requiring significant download time
+- Used for GPT-2 reproduction
+
+### Custom Datasets
+- Follow patterns in `data/shakespeare/` or `data/openwebtext/`
+- Implement `prepare.py` script for tokenization
+- Output `train.bin` and `val.bin` files
+
+## Model Configurations
+
+### Baby GPT (Shakespeare)
+- 6 layers, 6 heads, 384 embedding dim
+- Context length: 256 characters
+- ~3 minutes training on A100
+
+### GPT-2 Reproduction
+- 124M parameters: 12 layers, 12 heads, 768 embedding dim
+- 350M, 774M, 1558M variants available
+- Context length: 1024 tokens
+
+## Device Support
+
+### GPU (CUDA)
+- Default configuration
+- Use `--device=cuda` explicitly if needed
+
+### CPU
+- Add `--device=cpu --compile=False`
+- Reduce model size and batch size for feasibility
+
+### Apple Silicon (MPS)
+- Add `--device=mps` for Metal GPU acceleration
+- 2-3x speedup over CPU on Apple Silicon
+
+## Troubleshooting
+
+### PyTorch 2.0 Issues
+- Add `--compile=False` to disable torch.compile
+- This will slow down training but improve compatibility
+
+### Memory Issues
+- Reduce `batch_size` or `block_size`
+- Use smaller model configurations
+- Enable gradient accumulation instead of larger batch sizes
+
+### Multi-GPU Issues
+- Ensure proper torchrun usage
+- Check NCCL configuration for multi-node setups
+- Prepend `NCCL_IB_DISABLE=1` if no Infiniband
+
+## No Testing Framework
+
+This repository does not include a formal testing framework. Validation is performed through:
+- Model evaluation on validation sets
+- Loss monitoring during training
+- Generated text quality assessment
+- Comparison with baseline GPT-2 results
+
+## ALiBi (Attention with Linear Biases) Support
+
+ALiBi enables models to extrapolate to longer sequences at inference time than they were trained on.
+
+### Key Features
+- **Length Extrapolation**: Models trained on sequence length N can handle sequences of length 2N+ at inference
+- **No Positional Embeddings**: ALiBi replaces standard positional embeddings with attention biases
+- **Memory Efficient**: Uses linear biases instead of learned position embeddings
+- **Causal Masking**: Maintains causal attention patterns
+
+### Configuration
+```python
+use_alibi = True  # Enable ALiBi in model config
+```
+
+### ALiBi Training Examples
+```bash
+# Train character-level Shakespeare model with ALiBi
+python train.py config/train_shakespeare_char_alibi.py
+
+# Train GPT-2 with ALiBi
+torchrun --standalone --nproc_per_node=8 train.py config/train_gpt2_alibi.py
+```
+
+### Testing Length Extrapolation
+```bash
+# Test ALiBi extrapolation capabilities
+python sample_alibi_extrapolation.py
+
+# Test with trained model
+python sample_alibi_extrapolation.py out-shakespeare-char-alibi
+```
+
+### Implementation Details
+- ALiBi slopes are computed automatically based on number of heads
+- Biases are applied directly to attention scores before softmax
+- Flash Attention is disabled when using ALiBi
+- Models can handle sequences longer than `block_size` at inference
+
+## Logging and Monitoring
+
+### Weights & Biases
+- Set `wandb_log = True` in config
+- Configure `wandb_project` and `wandb_run_name`
+- Automatic logging of losses, learning rates, and metrics
+
+### Local Logging
+- Training progress printed to console
+- Checkpoints saved to `out_dir`
+- Loss curves and metrics tracked

--- a/config/train_gpt2_alibi.py
+++ b/config/train_gpt2_alibi.py
@@ -1,0 +1,32 @@
+# config for training GPT-2 (124M) with ALiBi down to very nice loss
+# This config trains on sequences of length 1024 but can extrapolate to longer sequences at inference
+# launch as the following (e.g. in a screen session):
+# $ torchrun --standalone --nproc_per_node=8 train.py config/train_gpt2_alibi.py
+
+wandb_log = True
+wandb_project = 'owt-alibi'
+wandb_run_name='gpt2-124M-alibi'
+
+# these make the total batch size be ~0.5M
+# 12 batch size * 1024 block size * 5 gradaccum * 8 GPUs = 491,520
+batch_size = 12
+block_size = 1024
+gradient_accumulation_steps = 5 * 8
+
+# this makes total number of tokens be 300B
+max_iters = 600000
+lr_decay_iters = 600000
+
+# eval stuff
+eval_interval = 1000
+eval_iters = 200
+log_interval = 10
+
+# weight decay
+weight_decay = 1e-1
+
+# ALiBi configuration
+use_alibi = True  # Enable ALiBi attention for length extrapolation
+
+# Note: With ALiBi, the model can handle longer sequences at inference time
+# without additional training or fine-tuning

--- a/config/train_shakespeare_char_alibi.py
+++ b/config/train_shakespeare_char_alibi.py
@@ -1,0 +1,39 @@
+# train a miniature character-level shakespeare model with ALiBi
+# This demonstrates ALiBi's ability to handle longer sequences at inference time
+# compared to training time
+
+out_dir = 'out-shakespeare-char-alibi'
+eval_interval = 250 # keep frequent because we'll overfit
+eval_iters = 200
+log_interval = 10 # don't print too too often
+
+# we expect to overfit on this small dataset, so only save when val improves
+always_save_checkpoint = False
+
+wandb_log = False # override via command line if you like
+wandb_project = 'shakespeare-char-alibi'
+wandb_run_name = 'mini-gpt-alibi'
+
+dataset = 'shakespeare_char'
+gradient_accumulation_steps = 1
+batch_size = 64
+block_size = 256 # context of up to 256 previous characters
+
+# baby GPT model with ALiBi :)
+n_layer = 6
+n_head = 6
+n_embd = 384
+dropout = 0.2
+use_alibi = True  # Enable ALiBi attention
+
+learning_rate = 1e-3 # with baby networks can afford to go a bit higher
+max_iters = 5000
+lr_decay_iters = 5000 # make equal to max_iters usually
+min_lr = 1e-4 # learning_rate / 10 usually
+beta2 = 0.99 # make a bit bigger because number of tokens per iter is small
+
+warmup_iters = 100 # not super necessary potentially
+
+# on macbook also add
+# device = 'cpu'  # run on cpu only
+# compile = False # do not torch compile the model

--- a/sample_alibi_extrapolation.py
+++ b/sample_alibi_extrapolation.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Demonstration of ALiBi's length extrapolation capabilities.
+This script shows how a model trained on sequences of length N can generate
+sequences of length 2N or more at inference time.
+"""
+
+import os
+import pickle
+import torch
+from model import GPT, GPTConfig
+
+def load_model_and_generate(out_dir, max_length_multiplier=2.0, num_samples=3):
+    """
+    Load a trained ALiBi model and generate samples at different lengths.
+    
+    Args:
+        out_dir: Directory containing the trained model
+        max_length_multiplier: How much longer than training length to generate
+        num_samples: Number of samples to generate
+    """
+    
+    # Load the trained model
+    ckpt_path = os.path.join(out_dir, 'ckpt.pt')
+    checkpoint = torch.load(ckpt_path, map_location='cpu')
+    
+    # Create model from checkpoint
+    model_args = checkpoint['model_args']
+    gptconf = GPTConfig(**model_args)
+    model = GPT(gptconf)
+    model.load_state_dict(checkpoint['model'])
+    model.eval()
+    
+    # Load tokenizer/encoding info
+    meta_path = os.path.join('data', gptconf.dataset if hasattr(gptconf, 'dataset') else 'shakespeare_char', 'meta.pkl')
+    if os.path.exists(meta_path):
+        with open(meta_path, 'rb') as f:
+            meta = pickle.load(f)
+        stoi, itos = meta['stoi'], meta['itos']
+        encode = lambda s: [stoi[c] for c in s]
+        decode = lambda l: ''.join([itos[i] for i in l])
+    else:
+        # fallback to GPT-2 tokenizer
+        import tiktoken
+        enc = tiktoken.get_encoding("gpt2")
+        encode = lambda s: enc.encode(s, allowed_special={"<|endoftext|>"})
+        decode = lambda l: enc.decode(l)
+    
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    model.to(device)
+    
+    # Test different sequence lengths
+    training_length = gptconf.block_size
+    test_lengths = [training_length, int(training_length * 1.5), int(training_length * max_length_multiplier)]
+    
+    # Starting prompt
+    start_prompt = "ROMEO:\nBut soft! What light through yonder window breaks?\nIt is the east, and Juliet is the sun."
+    if hasattr(gptconf, 'dataset') and gptconf.dataset == 'shakespeare_char':
+        start_ids = encode(start_prompt[:50])  # Truncate for character-level
+    else:
+        start_ids = encode(start_prompt)
+    
+    x = torch.tensor(start_ids, dtype=torch.long, device=device)[None, ...]
+    
+    print(f"Model trained on sequences of length: {training_length}")
+    print(f"Using ALiBi: {gptconf.use_alibi}")
+    print(f"Starting prompt: {decode(start_ids)}")
+    print("=" * 80)
+    
+    for test_length in test_lengths:
+        print(f"\nGenerating {num_samples} samples at length {test_length} (ratio: {test_length/training_length:.1f}x):")
+        print("-" * 60)
+        
+        # Calculate how many new tokens to generate
+        max_new_tokens = max(1, test_length - len(start_ids))
+        
+        for i in range(num_samples):
+            with torch.no_grad():
+                # Modify the generation method to allow longer sequences
+                original_block_size = model.config.block_size
+                if gptconf.use_alibi:
+                    # Temporarily increase the effective block size for ALiBi models
+                    model.config.block_size = test_length
+                
+                try:
+                    y = model.generate(x, max_new_tokens, temperature=0.8, top_k=200)
+                    generated_text = decode(y[0].tolist())
+                    
+                    print(f"Sample {i+1}:")
+                    print(generated_text)
+                    print()
+                    
+                finally:
+                    # Restore original block size
+                    model.config.block_size = original_block_size
+    
+    return model
+
+def compare_standard_vs_alibi():
+    """
+    Compare standard positional embeddings vs ALiBi on length extrapolation.
+    This creates two small models and shows the difference.
+    """
+    print("Comparing Standard vs ALiBi models on length extrapolation...")
+    print("=" * 80)
+    
+    # Create small models for comparison
+    config_std = GPTConfig(
+        block_size=64,
+        vocab_size=50,
+        n_layer=4,
+        n_head=4,
+        n_embd=256,
+        use_alibi=False
+    )
+    
+    config_alibi = GPTConfig(
+        block_size=64,
+        vocab_size=50,
+        n_layer=4,
+        n_head=4,
+        n_embd=256,
+        use_alibi=True
+    )
+    
+    model_std = GPT(config_std)
+    model_alibi = GPT(config_alibi)
+    
+    # Create test sequence longer than training length
+    test_seq_len = 96  # 1.5x the training length
+    x = torch.randint(0, 50, (1, test_seq_len))
+    
+    print(f"Training length: {config_std.block_size}")
+    print(f"Test sequence length: {test_seq_len}")
+    print(f"Extrapolation ratio: {test_seq_len / config_std.block_size:.1f}x")
+    
+    # Test standard model (should fail or perform poorly)
+    print("\nTesting Standard Positional Embeddings Model:")
+    try:
+        with torch.no_grad():
+            logits_std, _ = model_std(x[:, :config_std.block_size], targets=x[:, :config_std.block_size])
+            print(f"✓ Standard model works at training length: {logits_std.shape}")
+            
+            # This should fail or perform poorly
+            try:
+                logits_std_long, _ = model_std(x, targets=x)
+                print(f"✗ Standard model at {test_seq_len} length: {logits_std_long.shape} (unexpected success)")
+            except Exception as e:
+                print(f"✓ Standard model fails at {test_seq_len} length: {str(e)}")
+    except Exception as e:
+        print(f"✗ Standard model failed: {str(e)}")
+    
+    # Test ALiBi model (should work)
+    print("\nTesting ALiBi Model:")
+    try:
+        with torch.no_grad():
+            logits_alibi, _ = model_alibi(x[:, :config_alibi.block_size], targets=x[:, :config_alibi.block_size])
+            print(f"✓ ALiBi model works at training length: {logits_alibi.shape}")
+            
+            logits_alibi_long, _ = model_alibi(x, targets=x)
+            print(f"✓ ALiBi model works at {test_seq_len} length: {logits_alibi_long.shape}")
+    except Exception as e:
+        print(f"✗ ALiBi model failed: {str(e)}")
+
+if __name__ == "__main__":
+    import sys
+    
+    if len(sys.argv) > 1:
+        out_dir = sys.argv[1]
+        if os.path.exists(out_dir):
+            print(f"Loading model from {out_dir}...")
+            load_model_and_generate(out_dir)
+        else:
+            print(f"Directory {out_dir} does not exist.")
+            print("Usage: python sample_alibi_extrapolation.py <model_output_dir>")
+    else:
+        print("No model directory provided. Running comparison demo...")
+        compare_standard_vs_alibi()
+        print("\n" + "=" * 80)
+        print("To test with a trained model, run:")
+        print("python sample_alibi_extrapolation.py <model_output_dir>")
+        print("\nExample:")
+        print("python sample_alibi_extrapolation.py out-shakespeare-char-alibi")


### PR DESCRIPTION
…polation

Add support for ALiBi as described in "Train Short, Test Long: Attention with Linear Biases Enables Input Length Extrapolation" (arXiv:2108.12409). ALiBi allows models to handle sequences longer at inference time than they were trained on.

Key changes:
- Add use_alibi config parameter to GPTConfig
- Implement ALiBi slope generation and bias calculation in CausalSelfAttention
- Replace positional embeddings with linear attention biases when ALiBi is enabled
- Add length extrapolation support in generation method
- Disable Flash Attention when using ALiBi (incompatible)
- Add ALiBi training configs for Shakespeare and GPT-2
- Add demonstration script for testing length extrapolation
- Update documentation with ALiBi usage instructions

Features:
- Models trained on length N can extrapolate to length 2N+ at inference
- Maintains causal attention while enabling length generalization
- Reduces memory usage by eliminating positional embedding parameters
- Automatic slope computation based on number of attention heads

🤖 Generated with [Claude Code](https://claude.ai/code)