### PR TITLE
Replacing DDP with FSDP since it has sharing capability train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,6 +25,8 @@ from contextlib import nullcontext
 import numpy as np
 import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.distributed import FullyShardedDataParellel as FSDF
+from torch.distributed.fsdf.wrap import default_auto_wrap_policy
 from torch.distributed import init_process_group, destroy_process_group
 
 from model import GPTConfig, GPT


### PR DESCRIPTION
I just imported the libs necessary to replace DDP with FSDP, I think that sending the model to GPU isn’t as efficient as sharing, so lets replace DDP, if I get positive response I will continue working on it, the PR is now at 5% completion