### PR TITLE
Updating link to Better Language Models PDF in CDN

### DIFF
--- a/data/openwebtext/readme.md
+++ b/data/openwebtext/readme.md
@@ -11,5 +11,5 @@ this came from 8,013,769 documents in total.
 
 references:
 
-- OpenAI's WebText dataset is discussed in [GPT-2 paper](https://d4mucfpksywv.cloudfront.net/better-language-models/language_models_are_unsupervised_multitask_learners.pdf)
+- OpenAI's WebText dataset is discussed in [GPT-2 paper](https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf)
 - [OpenWebText](https://skylion007.github.io/OpenWebTextCorpus/) dataset


### PR DESCRIPTION
@karpathy: This change updates the broken link for the OpenAI _Better Language Models_ paper in the CDN.

Thanks.

