### PR TITLE
Remove unnecessary conditional cropping of sequence context in `generate()`

### DIFF
--- a/model.py
+++ b/model.py
@@ -311,7 +311,7 @@ class GPT(nn.Module):
         """
         for _ in range(max_new_tokens):
             # if the sequence context is growing too long we must crop it at block_size
-            cropped_idx = idx[:, -self.config.block_size :]
+            cropped_idx = idx[:, -self.config.block_size:]
             # forward the model to get the logits for the index in the sequence
             logits, _ = self(cropped_idx)
             # pluck the logits at the final step and scale by desired temperature

--- a/model.py
+++ b/model.py
@@ -311,9 +311,9 @@ class GPT(nn.Module):
         """
         for _ in range(max_new_tokens):
             # if the sequence context is growing too long we must crop it at block_size
-            idx_cond = idx if idx.size(1) <= self.config.block_size else idx[:, -self.config.block_size:]
+            cropped_idx = idx[:, -self.config.block_size :]
             # forward the model to get the logits for the index in the sequence
-            logits, _ = self(idx_cond)
+            logits, _ = self(cropped_idx)
             # pluck the logits at the final step and scale by desired temperature
             logits = logits[:, -1, :] / temperature
             # optionally crop the logits to only the top k options


### PR DESCRIPTION
In python, negative slicing is "clamped" to the available range. If the tensor's dimension is smaller than the slice size, it just returns all elements without any error. For this reason, we can always call `idx[:, -self.config.block_size:]` regardless of the value of `idx.size(1)`.

