### PR TITLE
Distributed Evaluation for Acceleration

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ from contextlib import nullcontext
 import numpy as np
 import torch
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.distributed import init_process_group, destroy_process_group
+from torch.distributed import init_process_group, destroy_process_group, reduce, ReduceOp
 
 from model import GPTConfig, GPT
 
@@ -93,6 +93,7 @@ if ddp:
     # down the desired gradient accumulation iterations per process proportionally
     assert gradient_accumulation_steps % ddp_world_size == 0
     gradient_accumulation_steps //= ddp_world_size
+    eval_iters //= ddp_world_size
 else:
     # if not ddp, we are running on a single gpu, and one process
     master_process = True
@@ -217,13 +218,15 @@ def estimate_loss():
     out = {}
     model.eval()
     for split in ['train', 'val']:
-        losses = torch.zeros(eval_iters)
+        losses = torch.zeros(eval_iters, device=device)
         for k in range(eval_iters):
             X, Y = get_batch(split)
             with ctx:
                 logits, loss = model(X, Y)
-            losses[k] = loss.item()
+            losses[k] = loss
         out[split] = losses.mean()
+        if ddp:
+            reduce(out[split], 0, ReduceOp.AVG)
     model.train()
     return out
 
@@ -260,30 +263,31 @@ while True:
         param_group['lr'] = lr
 
     # evaluate the loss on train/val sets and write checkpoints
-    if iter_num % eval_interval == 0 and master_process:
+    if iter_num % eval_interval == 0:
         losses = estimate_loss()
-        print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
-        if wandb_log:
-            wandb.log({
-                "iter": iter_num,
-                "train/loss": losses['train'],
-                "val/loss": losses['val'],
-                "lr": lr,
-                "mfu": running_mfu*100, # convert to percentage
-            })
-        if losses['val'] < best_val_loss or always_save_checkpoint:
-            best_val_loss = losses['val']
-            if iter_num > 0:
-                checkpoint = {
-                    'model': raw_model.state_dict(),
-                    'optimizer': optimizer.state_dict(),
-                    'model_args': model_args,
-                    'iter_num': iter_num,
-                    'best_val_loss': best_val_loss,
-                    'config': config,
-                }
-                print(f"saving checkpoint to {out_dir}")
-                torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
+        if master_process:
+            print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
+            if wandb_log:
+                wandb.log({
+                    "iter": iter_num,
+                    "train/loss": losses['train'],
+                    "val/loss": losses['val'],
+                    "lr": lr,
+                    "mfu": running_mfu*100, # convert to percentage
+                })
+            if losses['val'] < best_val_loss or always_save_checkpoint:
+                best_val_loss = losses['val']
+                if iter_num > 0:
+                    checkpoint = {
+                        'model': raw_model.state_dict(),
+                        'optimizer': optimizer.state_dict(),
+                        'model_args': model_args,
+                        'iter_num': iter_num,
+                        'best_val_loss': best_val_loss,
+                        'config': config,
+                    }
+                    print(f"saving checkpoint to {out_dir}")
+                    torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
     if iter_num == 0 and eval_only:
         break
 


### PR DESCRIPTION
Adjust loss estimation using DDP support. `estimate_loss` now is run across all devices to save up time.
`torchrun --standalone --nproc_per_node=4 train.py` with `eval_interval=2` reduces eval iteration time from 21s to 8s, 38% speed for eval iteration.
Old branch
```
step 0: train loss 10.9886, val loss 10.9897
iter 0: loss 10.9766, time 26086.69ms, mfu -100.00%
iter 1: loss 10.9558, time 813.91ms, mfu -100.00%
step 2: train loss 10.9370, val loss 10.9377
saving checkpoint to out
iter 2: loss 10.9481, time 20176.69ms, mfu -100.00%
iter 3: loss 10.8799, time 923.17ms, mfu -100.00%
step 4: train loss 10.8181, val loss 10.8185
saving checkpoint to out
iter 4: loss 10.8340, time 20753.85ms, mfu -100.00%
iter 5: loss 10.7294, time 923.15ms, mfu 36.47%
step 6: train loss 10.6521, val loss 10.6532
saving checkpoint to out
iter 6: loss 10.6651, time 20960.05ms, mfu 32.98%
iter 7: loss 10.5586, time 923.50ms, mfu 33.33%
step 8: train loss 10.4676, val loss 10.4699
saving checkpoint to out
iter 8: loss 10.4841, time 20972.46ms, mfu 30.16%
iter 9: loss 10.4411, time 924.84ms, mfu 30.78%
```
 New branch
```
step 0: train loss 10.9894, val loss 10.9906
iter 0: loss 10.9944, time 13836.17ms, mfu -100.00%
iter 1: loss 10.9413, time 813.67ms, mfu -100.00%
step 2: train loss 10.9373, val loss 10.9382
saving checkpoint to out
iter 2: loss 10.9396, time 8738.35ms, mfu -100.00%
iter 3: loss 10.8950, time 928.53ms, mfu -100.00%
step 4: train loss 10.8183, val loss 10.8194
saving checkpoint to out
iter 4: loss 10.8238, time 8496.28ms, mfu -100.00%
iter 5: loss 10.7193, time 924.64ms, mfu 36.41%
step 6: train loss 10.6518, val loss 10.6492
saving checkpoint to out
iter 6: loss 10.6451, time 7954.27ms, mfu 33.19%
iter 7: loss 10.5497, time 923.82ms, mfu 33.52%
step 8: train loss 10.4732, val loss 10.4695
saving checkpoint to out
iter 8: loss 10.4469, time 7863.56ms, mfu 30.59%
iter 9: loss 10.3595, time 923.27ms, mfu 31.18%
```