### PR TITLE
Add textfile_char dataset preset for training on .txt files

### DIFF
--- a/data/textfile_char/data.txt
+++ b/data/textfile_char/data.txt
@@ -1,0 +1,10 @@
+<u> hi
+<a> hey, how can I help you today?
+<u> tell me a joke
+<a> sure, here's a joke for you:
+why did the tomato turn red?
+because it saw the salad dressing!
+<u> thanks, that was a good joke
+<a> you're welcome! 
+<u> bye
+<a> goodbye! have a great day!

--- a/data/textfile_char/prepare.py
+++ b/data/textfile_char/prepare.py
@@ -1,0 +1,58 @@
+"""
+Prepare the text files for character-level language modeling.
+Will save train.bin, val.bin containing the ids, and meta.pkl containing the
+encoder and decoder and some other related info.
+"""
+
+import os
+import pickle
+import numpy as np
+
+base_dir = os.path.dirname(__file__)
+data_chunks = []
+
+for root, dirs, files in os.walk(base_dir):
+    for file in files:
+        if file.endswith('.txt'):
+            file_path = os.path.join(root, file)
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    data_chunks.append(f.read())
+            except:
+                pass
+
+data = ''.join(data_chunks)
+
+if not data:
+    raise ValueError("No .txt data found")
+print(f"length of dataset in characters: {len(data):,}")
+
+chars = sorted(list(set(data)))
+vocab_size = len(chars)
+print("all the unique characters:", ''.join(chars))
+print(f"vocab size: {vocab_size:,}")
+
+stoi = {ch:i for i,ch in enumerate(chars)}
+itos = {i:ch for i,ch in enumerate(chars)}
+def encode(s):
+    return [stoi[c] for c in s]
+def decode(l):
+    return ''.join([itos[i] for i in l])
+
+n = len(data)
+train_data = data[:int(n*0.9)]
+val_data = data[int(n*0.9):]
+
+train_ids = encode(train_data)
+val_ids = encode(val_data)
+print(f"train has {len(train_ids):,} tokens")
+print(f"val has {len(val_ids):,} tokens")
+
+train_ids = np.array(train_ids, dtype=np.uint16)
+val_ids = np.array(val_ids, dtype=np.uint16)
+train_ids.tofile(os.path.join(base_dir, 'train.bin'))
+val_ids.tofile(os.path.join(base_dir, 'val.bin'))
+
+meta = {'vocab_size': vocab_size, 'itos': itos, 'stoi': stoi}
+with open(os.path.join(base_dir, 'meta.pkl'), 'wb') as f:
+    pickle.dump(meta, f)


### PR DESCRIPTION
Adds `textfile_char` dataset preset for training NanoGPT on arbitrary `.txt` files
by scanning the dataset folder and creating character-level bin/meta
files. Does not modify existing datasets.
