### PR TITLE
Fix MPS device detection and deprecated GradScaler API

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -25,7 +25,7 @@ torch.manual_seed(seed)
 torch.cuda.manual_seed(seed)
 torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
 torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
-device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast
+device_type = 'cuda' if 'cuda' in device else ('mps' if 'mps' in device else 'cpu') # for later use in torch.autocast
 ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
 ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
 

--- a/sample.py
+++ b/sample.py
@@ -27,7 +27,7 @@ torch.manual_seed(seed)
 torch.cuda.manual_seed(seed)
 torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
 torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
-device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast
+device_type = 'cuda' if 'cuda' in device else ('mps' if 'mps' in device else 'cpu') # for later use in torch.autocast
 ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
 ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
 

--- a/train.py
+++ b/train.py
@@ -106,7 +106,7 @@ if master_process:
 torch.manual_seed(1337 + seed_offset)
 torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
 torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
-device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast
+device_type = 'cuda' if 'cuda' in device else ('mps' if 'mps' in device else 'cpu') # for later use in torch.autocast
 # note: float16 data type will automatically use a GradScaler
 ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
 ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
@@ -193,7 +193,7 @@ if block_size < model.config.block_size:
 model.to(device)
 
 # initialize a GradScaler. If enabled=False scaler is a no-op
-scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
+scaler = torch.amp.GradScaler(device_type, enabled=(dtype == 'float16' and device_type == 'cuda'))
 
 # optimizer
 optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)


### PR DESCRIPTION
## Summary

- **Fix `device_type` detection to handle MPS (Apple Silicon).** The current code only distinguishes between `'cuda'` and `'cpu'`, so setting `device = 'mps'` causes `device_type` to be `'cpu'`. This silently skips `torch.amp.autocast` (uses `nullcontext()` instead), losing mixed-precision benefits on MPS. The fix adds proper `'mps'` detection in `train.py`, `sample.py`, and `bench.py`.

- **Replace deprecated `torch.cuda.amp.GradScaler` with `torch.amp.GradScaler`.** The old API emits a `FutureWarning` and will be removed in a future PyTorch release. The scaler is now only enabled for CUDA + float16, where loss scaling is actually needed and supported.

Fixes #654, fixes #635.

## Test plan

- [ ] Run `python train.py --device=mps` on an Apple Silicon Mac and verify autocast is active (not `nullcontext`)
- [ ] Run `python train.py --device=cuda` on a CUDA machine and verify GradScaler works with float16
- [ ] Run `python train.py --device=cpu` and verify training still works (scaler disabled, no autocast)
- [ ] Confirm no `FutureWarning` about `torch.cuda.amp.GradScaler` is emitted