### PR TITLE
fix: ZeroDivisionError in get_lr when lr_decay_iters == warmup_iters

### DIFF
--- a/train.py
+++ b/train.py
@@ -236,7 +236,7 @@ def get_lr(it):
     if it > lr_decay_iters:
         return min_lr
     # 3) in between, use cosine decay down to min learning rate
-    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
+    decay_ratio = (it - warmup_iters) / max(1, lr_decay_iters - warmup_iters)
     assert 0 <= decay_ratio <= 1
     coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio)) # coeff ranges 0..1
     return min_lr + coeff * (learning_rate - min_lr)


### PR DESCRIPTION
## Bug

`get_lr()` divides by zero exactly at the warmup/decay boundary when `lr_decay_iters == warmup_iters`:

```python
warmup_iters = 100
lr_decay_iters = 100
it = 100
# (it - warmup_iters) / (lr_decay_iters - warmup_iters) => 0 / 0
```

This can occur in short experimental configurations that intentionally disable the cosine-decay interval.

## Fix

Clamp the decay interval denominator to at least one:

```python
decay_ratio = (it - warmup_iters) / max(1, lr_decay_iters - warmup_iters)
```

At the zero-length boundary, the numerator is also zero, so the scheduler returns the peak learning rate. Iterations after `lr_decay_iters` still return `min_lr` through the existing earlier branch, and normal positive-length schedules are unchanged.