### PR TITLE
Fix deprecated torch.cuda.amp.GradScaler API

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,160 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'model.py'
+      - 'train.py'
+      - 'config/*.py'
+      - '*.py'
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'model.py'
+      - 'train.py'
+      - 'config/*.py'
+      - '*.py'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch full history for git diff
+        
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+        
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 black isort
+        
+    - name: Get changed Python files
+      id: changed-files
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          # For PRs, compare against the base branch
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          CHANGED_FILES=$(git diff --name-only --diff-filter=AM $BASE_SHA...$HEAD_SHA | grep -E '\.(py)$' | grep -E '^(model\.py|train\.py|config/.*\.py)$' || true)
+        else
+          # For pushes, compare against the previous commit
+          CHANGED_FILES=$(git diff --name-only --diff-filter=AM HEAD~1 HEAD | grep -E '\.(py)$' | grep -E '^(model\.py|train\.py|config/.*\.py)$' || true)
+        fi
+        
+        echo "changed_files<<EOF" >> $GITHUB_OUTPUT
+        echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+        
+        # Also set a flag if any files were found
+        if [ -n "$CHANGED_FILES" ]; then
+          echo "has_files=true" >> $GITHUB_OUTPUT
+        else
+          echo "has_files=false" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Run flake8
+      if: steps.changed-files.outputs.has_files == 'true'
+      id: flake8
+      run: |
+        echo "Running flake8 on changed files..."
+        echo "${{ steps.changed-files.outputs.changed_files }}"
+        
+        # Create output file for flake8 results
+        FLAKE8_OUTPUT=$(mktemp)
+        EXIT_CODE=0
+        
+        # Run flake8 on changed files
+        echo "${{ steps.changed-files.outputs.changed_files }}" | while read -r file; do
+          if [ -n "$file" ] && [ -f "$file" ]; then
+            echo "Checking $file with flake8..."
+            flake8 "$file" --max-line-length=88 --extend-ignore=E203,W503 || EXIT_CODE=$?
+          fi
+        done > "$FLAKE8_OUTPUT" 2>&1
+        
+        # Check if flake8 found any issues
+        if [ -s "$FLAKE8_OUTPUT" ]; then
+          echo "flake8_errors<<EOF" >> $GITHUB_OUTPUT
+          cat "$FLAKE8_OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "flake8_failed=true" >> $GITHUB_OUTPUT
+          exit 1
+        else
+          echo "flake8_failed=false" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Run black --check
+      if: steps.changed-files.outputs.has_files == 'true'
+      id: black
+      run: |
+        echo "Running black --check on changed files..."
+        BLACK_OUTPUT=$(mktemp)
+        EXIT_CODE=0
+        
+        echo "${{ steps.changed-files.outputs.changed_files }}" | while read -r file; do
+          if [ -n "$file" ] && [ -f "$file" ]; then
+            echo "Checking $file with black..."
+            black --check --diff "$file" || EXIT_CODE=$?
+          fi
+        done > "$BLACK_OUTPUT" 2>&1
+        
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "black_errors<<EOF" >> $GITHUB_OUTPUT
+          cat "$BLACK_OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "black_failed=true" >> $GITHUB_OUTPUT
+          exit 1
+        else
+          echo "black_failed=false" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Run isort --check
+      if: steps.changed-files.outputs.has_files == 'true'
+      id: isort
+      run: |
+        echo "Running isort --check on changed files..."
+        ISORT_OUTPUT=$(mktemp)
+        EXIT_CODE=0
+        
+        echo "${{ steps.changed-files.outputs.changed_files }}" | while read -r file; do
+          if [ -n "$file" ] && [ -f "$file" ]; then
+            echo "Checking $file with isort..."
+            isort --check-only --diff "$file" --profile black || EXIT_CODE=$?
+          fi
+        done > "$ISORT_OUTPUT" 2>&1
+        
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "isort_errors<<EOF" >> $GITHUB_OUTPUT
+          cat "$ISORT_OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "isort_failed=true" >> $GITHUB_OUTPUT
+          exit 1
+        else
+          echo "isort_failed=false" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Comment PR with lint errors
+      if: |
+        github.event_name == 'pull_request' && 
+        (steps.flake8.outputs.flake8_failed == 'true' || 
+         steps.black.outputs.black_failed == 'true' || 
+         steps.isort.outputs.isort_failed == 'true')
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const flake8Errors = `${{ steps.flake8.outputs.flake8_errors || '' }}`;
+          const blackErrors = `${{ steps.black.outputs.black_errors || '' }}`;
+          const isortErrors = `${{ steps.isort.outputs.isort_errors || '' }}`;
+          
+          let comment = '## 🚨 Lint Issues Found\n\n';
+          comment += 'The following linting issues were found in your changes:\n\n';
+          
+          if (flake8Errors) {
+            comment += '### Flake8 Issues\n

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,219 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**.py'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install Claude Code CLI
+        run: |
+          pip install claude-code-cli
+          
+      - name: Run Claude Code Review
+        id: review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Create output directory
+          mkdir -p review-output
+          
+          # Run Claude Code review with JSON output
+          claude-code review \
+            --output-format json \
+            --files model.py train.py \
+            --severity-levels error,warning,suggestion \
+            --output review-output/results.json || echo "Review completed with findings"
+          
+          # Store results for next step
+          echo "results_file=review-output/results.json" >> $GITHUB_OUTPUT
+
+      - name: Parse Review Results and Post Comments
+        uses: actions/github-script@v7
+        env:
+          RESULTS_FILE: ${{ steps.review.outputs.results_file }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            
+            // Read Claude Code review results
+            const resultsPath = process.env.RESULTS_FILE;
+            if (!fs.existsSync(resultsPath)) {
+              console.log('No review results found');
+              return;
+            }
+            
+            const reviewData = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+            
+            // Parse findings and post comments
+            await postReviewComments(reviewData);
+            
+            async function postReviewComments(data) {
+              const { findings, summary } = data;
+              
+              // Post summary comment
+              await postSummaryComment(summary);
+              
+              // Post individual finding comments
+              for (const finding of findings) {
+                await postFindingComment(finding);
+              }
+            }
+            
+            async function postSummaryComment(summary) {
+              const { total_findings, by_severity, by_file } = summary;
+              
+              const severityEmojis = {
+                error: '🚨',
+                warning: '⚠️',
+                suggestion: '💡'
+              };
+              
+              let summaryText = `## 🤖 Claude Code Review Summary\n\n`;
+              summaryText += `**Total Findings:** ${total_findings}\n\n`;
+              
+              if (total_findings > 0) {
+                summaryText += `### By Severity\n`;
+                for (const [severity, count] of Object.entries(by_severity)) {
+                  if (count > 0) {
+                    summaryText += `${severityEmojis[severity]} **${severity.toUpperCase()}**: ${count}\n`;
+                  }
+                }
+                
+                summaryText += `\n### By File\n`;
+                for (const [file, count] of Object.entries(by_file)) {
+                  summaryText += `- \`${file}\`: ${count} findings\n`;
+                }
+              } else {
+                summaryText += `✅ No issues found! Code looks good.`;
+              }
+              
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: summaryText
+              });
+            }
+            
+            async function postFindingComment(finding) {
+              const { file, line, severity, category, title, description, suggestion, confidence } = finding;
+              
+              const severityEmojis = {
+                error: '🚨',
+                warning: '⚠️',
+                suggestion: '💡'
+              };
+              
+              const confidenceBar = '█'.repeat(Math.round(confidence / 10)) + 
+                                   '░'.repeat(10 - Math.round(confidence / 10));
+              
+              let commentBody = `### ${severityEmojis[severity]} ${title}\n\n`;
+              commentBody += `**Category:** ${category}\n`;
+              commentBody += `**Severity:** ${severity.toUpperCase()}\n`;
+              commentBody += `**Confidence:** ${confidence}% ${confidenceBar}\n\n`;
+              commentBody += `**Description:**\n${description}\n\n`;
+              
+              if (suggestion) {
+                commentBody += `**Suggested Fix:**\n${suggestion}\n\n`;
+              }
+              
+              commentBody += `---\n*Generated by Claude Code Review*`;
+              
+              // Get the commit SHA for the PR
+              const commits = await github.rest.pulls.listCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
+              
+              const latestCommit = commits.data[commits.data.length - 1];
+              
+              try {
+                await github.rest.pulls.createReviewComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number,
+                  commit_id: latestCommit.sha,
+                  path: file,
+                  line: line,
+                  body: commentBody
+                });
+              } catch (error) {
+                // Fallback to general comment if line comment fails
+                console.log(`Could not post line comment for ${file}:${line}, posting as general comment`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `**File: \`${file}\` Line: ${line}**\n\n${commentBody}`
+                });
+              }
+            }
+
+      - name: Set Review Status
+        uses: actions/github-script@v7
+        env:
+          RESULTS_FILE: ${{ steps.review.outputs.results_file }}
+        with:
+          script: |
+            const fs = require('fs');
+            
+            if (!fs.existsSync(process.env.RESULTS_FILE)) {
+              return;
+            }
+            
+            const reviewData = JSON.parse(fs.readFileSync(process.env.RESULTS_FILE, 'utf8'));
+            const { summary } = reviewData;
+            
+            // Determine overall status
+            const hasErrors = summary.by_severity.error > 0;
+            const hasWarnings = summary.by_severity.warning > 0;
+            
+            let conclusion = 'success';
+            let title = 'Claude Code Review Passed';
+            let summaryText = 'No critical issues found';
+            
+            if (hasErrors) {
+              conclusion = 'failure';
+              title = 'Claude Code Review Failed';
+              summaryText = `Found ${summary.by_severity.error} error(s) that need attention`;
+            } else if (hasWarnings) {
+              conclusion = 'neutral';
+              title = 'Claude Code Review Completed with Warnings';
+              summaryText = `Found ${summary.by_severity.warning} warning(s) to consider`;
+            }
+            
+            // Create check run
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Claude Code Review',
+              head_sha: context.payload.pull_request.head.sha,
+              status: 'completed',
+              conclusion: conclusion,
+              output: {
+                title: title,
+                summary: summaryText,
+                text: `Total findings: ${summary.total_findings}\n\nSee PR comments for detailed feedback.`
+              }
+            });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test Suite
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, master ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,226 @@
+name: Test Suite
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-python${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt', '**/pyproject.toml', '**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-python${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip wheel setuptools
+        pip install torch --index-url https://download.pytorch.org/whl/cpu
+        pip install numpy pytest pytest-cov pytest-xvfb pytest-html pytest-json-report
+        
+        # Install additional requirements if they exist
+        if [ -f requirements.txt ]; then
+          pip install -r requirements.txt
+        fi
+        if [ -f requirements-dev.txt ]; then
+          pip install -r requirements-dev.txt
+        fi
+        if [ -f pyproject.toml ]; then
+          pip install -e .
+        fi
+
+    - name: Verify installation
+      run: |
+        python -c "import torch; print(f'PyTorch version: {torch.__version__}')"
+        python -c "import numpy; print(f'NumPy version: {numpy.__version__}')"
+        python -c "import pytest; print(f'pytest version: {pytest.__version__}')"
+
+    - name: Create tests directory if it doesn't exist
+      run: |
+        mkdir -p tests
+        if [ ! -f tests/__init__.py ]; then
+          touch tests/__init__.py
+        fi
+        
+        # Create a basic test file if none exist
+        if [ -z "$(find tests -name 'test_*.py' -o -name '*_test.py')" ]; then
+          cat > tests/test_basic.py << 'EOF'
+        import sys
+        import os
+        
+        # Add the project root to Python path
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        
+        def test_imports():
+            """Test that basic imports work."""
+            try:
+                import torch
+                import numpy as np
+                assert True
+            except ImportError as e:
+                assert False, f"Import failed: {e}"
+        
+        def test_torch_basic():
+            """Test basic PyTorch functionality."""
+            import torch
+            x = torch.randn(2, 3)
+            assert x.shape == (2, 3)
+            assert x.dtype == torch.float32
+        
+        def test_numpy_basic():
+            """Test basic NumPy functionality."""
+            import numpy as np
+            x = np.random.randn(2, 3)
+            assert x.shape == (2, 3)
+            assert x.dtype == np.float64
+        EOF
+        fi
+
+    - name: Lint code (if flake8 is available)
+      continue-on-error: true
+      run: |
+        if pip show flake8 > /dev/null 2>&1; then
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        else
+          echo "flake8 not installed, skipping linting"
+        fi
+
+    - name: Run tests with pytest
+      id: pytest
+      run: |
+        pytest tests/ \
+          --verbose \
+          --tb=short \
+          --cov=. \
+          --cov-report=xml \
+          --cov-report=html \
+          --cov-report=term-missing \
+          --html=test-report.html \
+          --self-contained-html \
+          --json-report \
+          --json-report-file=test-report.json \
+          --junit-xml=junit.xml
+      continue-on-error: true
+
+    - name: Check test results
+      run: |
+        if [ ${{ steps.pytest.outcome }} != 'success' ]; then
+          echo "Tests failed or encountered errors"
+          exit 1
+        fi
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: test-results-python${{ matrix.python-version }}
+        path: |
+          test-report.html
+          test-report.json
+          junit.xml
+          htmlcov/
+          coverage.xml
+        retention-days: 30
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      if: matrix.python-version == '3.10'
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+
+    - name: Comment PR with test results
+      uses: actions/github-script@v6
+      if: github.event_name == 'pull_request' && always()
+      with:
+        script: |
+          const fs = require('fs');
+          let comment = `## Test Results for Python ${{ matrix.python-version }}\n\n`;
+          
+          try {
+            if (fs.existsSync('test-report.json')) {
+              const testReport = JSON.parse(fs.readFileSync('test-report.json', 'utf8'));
+              const summary = testReport.summary;
+              
+              comment += `- **Tests**: ${summary.total} total\n`;
+              comment += `- **Passed**: ${summary.passed || 0} ✅\n`;
+              comment += `- **Failed**: ${summary.failed || 0} ${summary.failed > 0 ? '❌' : '✅'}\n`;
+              comment += `- **Errors**: ${summary.error || 0} ${summary.error > 0 ? '❌' : '✅'}\n`;
+              comment += `- **Skipped**: ${summary.skipped || 0}\n`;
+              comment += `- **Duration**: ${summary.duration}s\n\n`;
+              
+              if (summary.failed > 0 || summary.error > 0) {
+                comment += `❌ Tests failed for Python ${{ matrix.python-version }}\n`;
+              } else {
+                comment += `✅ All tests passed for Python ${{ matrix.python-version }}\n`;
+              }
+            } else {
+              comment += `⚠️ Test report not found for Python ${{ matrix.python-version }}\n`;
+            }
+          } catch (error) {
+            comment += `⚠️ Error reading test report: ${error.message}\n`;
+          }
+          
+          // Only comment if this is the first Python version to avoid spam
+          if ('${{ matrix.python-version }}' === '3.10') {
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });
+          }
+
+  summary:
+    needs: test
+    runs-on: ubuntu-latest
+    if: always()
+    
+    steps:
+    - name: Check test results
+      run: |
+        if [[ "${{ needs.test.result }}" == "failure" ]]; then
+          echo "❌ Tests failed"
+          exit 1
+        elif [[ "${{ needs.test.result }}" == "cancelled" ]]; then
+          echo "⚠️ Tests were cancelled"
+          exit 1
+        else
+          echo "✅ All tests passed"
+        fi
+
+    - name: Report status
+      if: always()
+      run: |
+        echo "Test suite completed with status: ${{ needs.test.result }}"
+        echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# nanoGPT Project Configuration
+
+## ML-Specific Coding Standards
+
+### Tensor Shape Documentation
+- ALWAYS document tensor shapes in comments: `# (B, T, C)` format
+- Use `B` for batch, `T` for sequence/time, `C` for channels/embedding dim
+- Include shape comments for all forward() method inputs/outputs
+
+### Device-Agnostic Code
+- Never hardcode `.cuda()` - always use `device` parameter
+- Use `.to(device)` consistently for tensor operations
+- Check device compatibility before operations
+
+### Checkpoint Format
+- Checkpoints must include: model state, optimizer state, config, iter_num
+- Use descriptive checkpoint names with timestamps
+- Always validate checkpoint compatibility on load
+
+### Code Style
+- Follow GPT-2 paper conventions for naming (c_attn, c_proj, etc.)
+- Use descriptive variable names for hyperparameters
+- Keep architectural choices commented with paper references

--- a/data/CLAUDE.md
+++ b/data/CLAUDE.md
@@ -1,0 +1,19 @@
+# Data Pipeline Configuration
+
+## Data Directory Standards
+
+### prepare.py Conventions
+- Use numpy memmap for large datasets to avoid memory issues
+- 90/10 train/val split is standard
+- Save meta.pkl with vocab_size, encoder, decoder info
+- Use uint16 for token IDs (sufficient for most vocabularies)
+
+### Dataset Format
+- Binary format: train.bin, val.bin
+- Metadata: meta.pkl with pickle serialization
+- Document dataset statistics in comments (vocab size, token count)
+
+### Memory Management
+- Recreate memmap per batch to avoid memory leaks
+- Use dtype=np.uint16 for efficiency
+- Pin memory for GPU transfer when possible

--- a/extractions/extraction_summary.json
+++ b/extractions/extraction_summary.json
@@ -1,0 +1,244 @@
+{
+  "timestamp": "2026-03-16 12:56:08",
+  "demos_completed": {
+    "4.1_explicit_criteria": {
+      "critical": {
+        "class_names": {
+          "value": [
+            "GPT",
+            "GPTConfig",
+            "Block",
+            "CausalSelfAttention",
+            "MLP",
+            "LayerNorm"
+          ],
+          "confidence": 1.0,
+          "details": "All primary classes identified from code structure"
+        },
+        "layer_configuration": {
+          "n_layer": {
+            "value": 12,
+            "confidence": 1.0,
+            "details": "Default value in GPTConfig dataclass"
+          },
+          "n_head": {
+            "value": 12,
+            "confidence": 1.0,
+            "details": "Default value in GPTConfig dataclass"
+          },
+          "n_embd": {
+            "value": 768,
+            "confidence": 1.0,
+            "details": "Default value in GPTConfig dataclass"
+          }
+        },
+        "block_size": {
+          "value": 1024,
+          "confidence": 1.0,
+          "details": "Default value in GPTConfig dataclass"
+        },
+        "vocab_size": {
+          "value": 50304,
+          "confidence": 1.0,
+          "details": "Default value in GPTConfig, padded from GPT-2's 50257 to nearest multiple of 64"
+        },
+        "activation_functions": {
+          "value": [
+            "GELU",
+            "softmax"
+          ],
+          "confidence": 1.0,
+          "details": "GELU used in MLP class (nn.GELU()), softmax used in attention mechanism (F.softmax) and generation (F.softmax)"
+        },
+        "parameter_count_estimation": {
+          "value": "~124M for default config",
+          "confidence": 0.95,
+          "details": "Based on default config (12 layers, 12 heads, 768 embd). Model has get_num_params() method and prints parameter count during initialization. Default config matches GPT-2 small (124M params as noted in from_pretrained method)"
+        }
+      },
+      "warning": {
+        "dropout_settings": {
+          "value": 0.0,
+          "confidence": 1.0,
+          "details": "Default dropout rate in GPTConfig. Used in attention dropout, residual dropout, and main transformer dropout"
+        },
+        "bias_configuration": {
+          "value": true,
+          "confidence": 1.0,
+          "details": "Default bias=True in GPTConfig. Applied to Linear layers and LayerNorms. Comment notes False is 'a bit better and faster'"
+        },
+        "normalization_details": {
+          "value": "Custom LayerNorm with optional bias",
+          "confidence": 1.0,
+          "details": "Custom LayerNorm implementation allowing bias=False option, uses F.layer_norm with eps=1e-5"
+        },
+        "weight_initialization": {
+          "value": "Normal initialization with special scaled init for residual projections",
+          "confidence": 1.0,
+          "details": "Linear: normal(0, 0.02), Embedding: normal(0, 0.02), residual projections (c_proj): normal(0, 0.02/sqrt(2*n_layer))"
+        }
+      },
+      "info": {
+        "performance_optimizations": {
+          "flash_attention": {
+            "value": "Conditional Flash Attention support",
+            "confidence": 1.0,
+            "details": "Uses torch.nn.functional.scaled_dot_product_attention when available (PyTorch >= 2.0), falls back to manual attention implementation"
+          },
+          "torch_compile_ready": {
+            "value": "Weight tying compatible with torch.compile()",
+            "confidence": 0.9,
+            "details": "Code includes weight tying (wte.weight = lm_head.weight) with note about torch.compile() warnings"
+          },
+          "fused_adamw": {
+            "value": "Conditional fused AdamW optimizer",
+            "confidence": 1.0,
+            "details": "Uses fused AdamW when available and on CUDA device"
+          }
+        },
+        "special_features": {
+          "weight_tying": {
+            "value": "Token embedding and output layer weight sharing",
+            "confidence": 1.0,
+            "details": "self.transformer.wte.weight = self.lm_head.weight"
+          },
+          "pretrained_loading": {
+            "value": "HuggingFace GPT-2 checkpoint compatibility",
+            "confidence": 1.0,
+            "details": "from_pretrained method supports gpt2, gpt2-medium, gpt2-large, gpt2-xl with weight transposition handling"
+          },
+          "model_surgery": {
+            "value": "Block size cropping capability",
+            "confidence": 1.0,
+            "details": "crop_block_size method allows reducing block size after model creation"
+          }
+        },
+        "code_quality": {
+          "documentation": {
+            "value": "Well-documented with references",
+            "confidence": 1.0,
+            "details": "Includes references to OpenAI and HuggingFace implementations, detailed docstrings for key methods"
+          },
+          "implementation_style": {
+            "value": "Clean, single-file implementation",
+            "confidence": 1.0,
+            "details": "Self-contained implementation with clear separation of concerns, follows PyTorch best practices"
+          }
+        }
+      }
+    },
+    "4.2_few_shot_prompting": {
+      "layers": null,
+      "heads": "config.n_head",
+      "embedding_dim": "config.n_embd",
+      "vocab_size": null,
+      "block_size": "config.block_size",
+      "architecture_type": "transformer-decoder",
+      "framework": "pytorch",
+      "special_features": [
+        "causal_self_attention",
+        "flash_attention_support",
+        "custom_layer_norm",
+        "optional_bias",
+        "dropout_regularization"
+      ]
+    },
+    "4.3_structured_output": {
+      "model_data": {
+        "model_name": "GPT",
+        "base_class": "nn.Module",
+        "n_layer": 12,
+        "n_head": 12,
+        "n_embd": 768,
+        "block_size": 1024,
+        "vocab_size": 50304,
+        "activation_functions": [
+          "GELU"
+        ],
+        "normalization": "LayerNorm",
+        "attention_type": "CausalSelfAttention",
+        "dropout": 0.0,
+        "bias_type": "learned",
+        "bias_detail": "Configurable bias parameter for Linear layers and LayerNorms (default True)",
+        "weight_tying": true,
+        "components": [
+          {
+            "name": "Token Embeddings",
+            "type": "Embedding",
+            "details": "nn.Embedding(vocab_size, n_embd)"
+          },
+          {
+            "name": "Position Embeddings",
+            "type": "Embedding",
+            "details": "nn.Embedding(block_size, n_embd)"
+          },
+          {
+            "name": "Transformer Blocks",
+            "type": "ModuleList",
+            "details": "12 Block modules, each containing LayerNorm, CausalSelfAttention, and MLP"
+          },
+          {
+            "name": "Final LayerNorm",
+            "type": "LayerNorm",
+            "details": "Custom LayerNorm with optional bias"
+          },
+          {
+            "name": "Language Model Head",
+            "type": "Linear",
+            "details": "nn.Linear(n_embd, vocab_size, bias=False) with weight tying to token embeddings"
+          },
+          {
+            "name": "MLP",
+            "type": "Module",
+            "details": "Two Linear layers with GELU activation and dropout"
+          },
+          {
+            "name": "CausalSelfAttention",
+            "type": "Module",
+            "details": "Multi-head causal self-attention with Flash Attention support"
+          }
+        ],
+        "total_params_estimate": "124M (default config), scalable to 1558M for GPT2-XL variant"
+      },
+      "train_data": {
+        "config_name": "train_gpt2.py",
+        "wandb_log": true,
+        "wandb_project": "owt",
+        "batch_size": 12,
+        "gradient_accumulation_steps": 40,
+        "max_iters": 600000,
+        "eval_interval": 1000,
+        "eval_iters": 200,
+        "weight_decay": 0.1,
+        "optimizer": "<UNKNOWN>",
+        "learning_rate": "<UNKNOWN>"
+      }
+    },
+    "4.4_validation_retry": {
+      "n_layer": 12,
+      "n_head": 12,
+      "n_embd": 768,
+      "vocab_size": 50304,
+      "estimated_total_params": "124M",
+      "calculation_method": "Parameter count extracted from code comments in from_pretrained method, which states 'gpt2': dict(n_layer=12, n_head=12, n_embd=768), # 124M params. The model also includes a get_num_params() method that calculates: sum(p.numel() for p in self.parameters()) minus position embeddings for non-embedding count."
+    },
+    "4.5_batch_processing": {
+      "total_files": 4,
+      "successful": 0
+    },
+    "4.6_multi_pass_review": {
+      "pass1_results": {
+        "model.py": {
+          "error": "parse failed"
+        },
+        "config": {
+          "error": "parse failed"
+        }
+      },
+      "pass2_integration": "Since both files failed to parse, I cannot verify consistency between the configuration and model files. Let me return the appropriate response:\n\n```json\n{\n  \"consistent\": false,\n  \"conflicts\": [\"Cannot verify consistency - both model.py and config/train_shakespeare_char.py failed to parse\"],\n  \"reconciled_values\": {},\n  \"confidence\": 0.0\n}\n```\n\nTo properly verify consistency, I would need:\n1. Successfully parsed model.py to see default parameter values\n2. Successfully parsed config/train_shakespeare_char.py to see override values\n3. Ability to compare parameters like n_layer, n_head, n_embd, block_size, etc.\n\nWithout access to the actual parameter values from either file, I cannot determine if there are conflicts or provide reconciled values.",
+      "pass3_review": "Looking at the provided files, I can extract the following information:\n\n```json\n{\n  \"model_dimensions\": {\n    \"n_layer\": {\n      \"value\": 6,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: n_layer = 6\"\n    },\n    \"n_head\": {\n      \"value\": 6,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: n_head = 6\"\n    },\n    \"n_embd\": {\n      \"value\": 384,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: n_embd = 384\"\n    }\n  },\n  \"training_hyperparameters\": {\n    \"learning_rate\": {\n      \"value\": 0.001,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: learning_rate = 1e-3\"\n    },\n    \"batch_size\": {\n      \"value\": 64,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: batch_size = 64\"\n    },\n    \"block_size\": {\n      \"value\": 256,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: block_size = 256\"\n    },\n    \"dropout\": {\n      \"value\": 0.2,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: dropout = 0.2\"\n    },\n    \"max_iters\": {\n      \"value\": 5000,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: max_iters = 5000\"\n    },\n    \"lr_decay_iters\": {\n      \"value\": 5000,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: lr_decay_iters = 5000\"\n    },\n    \"min_lr\": {\n      \"value\": 0.0001,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: min_lr = 1e-4\"\n    },\n    \"beta2\": {\n      \"value\": 0.99,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: beta2 = 0.99\"\n    },\n    \"warmup_iters\": {\n      \"value\": 100,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: warmup_iters = 100\"\n    },\n    \"gradient_accumulation_steps\": {\n      \"value\": 1,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: gradient_accumulation_steps = 1\"\n    }\n  },\n  \"evaluation_parameters\": {\n    \"eval_interval\": {\n      \"value\": 250,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: eval_interval = 250\"\n    },\n    \"eval_iters\": {\n      \"value\": 200,\n      \"confidence\": 1.0,\n      \"source\": \"config/train_shakespeare_char.py line: eval_iters = 200\"\n    }\n  }\n}\n```\n\nAll confidence scores are 1.0 because these values are explicitly defined in the configuration file with clear variable assignments. The model.py file shows the GPT architecture implementation but the actual parameter values are sourced from the configuration file."
+    }
+  },
+  "source": "Domain 4 Capstone - Structured Data Extraction Pipeline",
+  "repository": "VizuaraAI/nanoGPT"
+}

--- a/extractions/model_architecture.json
+++ b/extractions/model_architecture.json
@@ -1,0 +1,56 @@
+{
+  "model_name": "GPT",
+  "base_class": "nn.Module",
+  "n_layer": 12,
+  "n_head": 12,
+  "n_embd": 768,
+  "block_size": 1024,
+  "vocab_size": 50304,
+  "activation_functions": [
+    "GELU"
+  ],
+  "normalization": "LayerNorm",
+  "attention_type": "CausalSelfAttention",
+  "dropout": 0.0,
+  "bias_type": "learned",
+  "bias_detail": "Configurable bias parameter for Linear layers and LayerNorms (default True)",
+  "weight_tying": true,
+  "components": [
+    {
+      "name": "Token Embeddings",
+      "type": "Embedding",
+      "details": "nn.Embedding(vocab_size, n_embd)"
+    },
+    {
+      "name": "Position Embeddings",
+      "type": "Embedding",
+      "details": "nn.Embedding(block_size, n_embd)"
+    },
+    {
+      "name": "Transformer Blocks",
+      "type": "ModuleList",
+      "details": "12 Block modules, each containing LayerNorm, CausalSelfAttention, and MLP"
+    },
+    {
+      "name": "Final LayerNorm",
+      "type": "LayerNorm",
+      "details": "Custom LayerNorm with optional bias"
+    },
+    {
+      "name": "Language Model Head",
+      "type": "Linear",
+      "details": "nn.Linear(n_embd, vocab_size, bias=False) with weight tying to token embeddings"
+    },
+    {
+      "name": "MLP",
+      "type": "Module",
+      "details": "Two Linear layers with GELU activation and dropout"
+    },
+    {
+      "name": "CausalSelfAttention",
+      "type": "Module",
+      "details": "Multi-head causal self-attention with Flash Attention support"
+    }
+  ],
+  "total_params_estimate": "124M (default config), scalable to 1558M for GPT2-XL variant"
+}

--- a/extractions/training_configs.json
+++ b/extractions/training_configs.json
@@ -1,0 +1,29 @@
+{
+  "configs": [
+    {
+      "custom_id": "config-train_gpt2",
+      "source_file": "config/train_gpt2.py",
+      "status": "parse_failed",
+      "raw_response": "```json\n{\n  \"config_name\": \"train_gpt2\",\n  \"batch_size\": 12,\n  \"learning_rate\": null,\n  \"max_iters\":"
+    },
+    {
+      "custom_id": "config-train_shakespeare_char",
+      "source_file": "config/train_shakespeare_char.py",
+      "status": "parse_failed",
+      "raw_response": "```json\n{\n  \"config_name\": \"train_shakespeare_char\",\n  \"batch_size\": 64,\n  \"learning_rate\": 0.001,\n "
+    },
+    {
+      "custom_id": "config-finetune_shakespeare",
+      "source_file": "config/finetune_shakespeare.py",
+      "status": "parse_failed",
+      "raw_response": "```json\n{\n  \"config_name\": \"finetune_shakespeare\",\n  \"batch_size\": 1,\n  \"learning_rate\": 3e-5,\n  \"ma"
+    },
+    {
+      "custom_id": "config-eval_gpt2",
+      "source_file": "config/eval_gpt2.py",
+      "status": "parse_failed",
+      "raw_response": "```json\n{\n  \"config_name\": \"eval_gpt2\",\n  \"batch_size\": 8,\n  \"learning_rate\": null,\n  \"max_iters\": n"
+    }
+  ],
+  "total_configs": 4
+}

--- a/research/errors.json
+++ b/research/errors.json
@@ -1,0 +1,20 @@
+[
+  {
+    "failure_type": "environment_constraint",
+    "attempted": "Analyze bench.py runtime performance characteristics",
+    "partial_results": {
+      "file_structure": "parsed",
+      "functions_identified": [
+        "benchmark_fn"
+      ],
+      "static_analysis": "completed"
+    },
+    "alternatives": [
+      "Static analysis only - no runtime benchmarks",
+      "Analyze configuration and setup code",
+      "Document CUDA requirement for future analysis"
+    ],
+    "should_retry": false,
+    "error_id": "E64620"
+  }
+]

--- a/research/findings.json
+++ b/research/findings.json
@@ -1,0 +1,101 @@
+[
+  {
+    "claim": "Uses transformer architecture with causal self-attention",
+    "source_file": "model.py",
+    "line_number": null,
+    "evidence": "```json\n[\n  {\n    \"claim\": \"Uses pre-normalization architecture pattern\",\n    \"line_number\": 104,\n    \"evidence\": \"x = x + self.attn(self.ln_1(x)) - LayerNorm is applied before attention, not after\",\n",
+    "confidence": 0.95,
+    "agent": "ArchitectureAgent",
+    "category": "architecture",
+    "finding_id": "F93092",
+    "timestamp": "2026-03-16T12:56:33.092589"
+  },
+  {
+    "claim": "Uses AdamW optimizer with cosine learning rate schedule",
+    "source_file": "train.py",
+    "line_number": null,
+    "evidence": "I can only see the header and imports of the file, but I can analyze what's visible. Let me examine the structure and make findings based on the available content:\n\n```json\n[\n  {\n    \"claim\": \"Script ",
+    "confidence": 0.9,
+    "agent": "TrainingAgent",
+    "category": "training",
+    "finding_id": "F13238",
+    "timestamp": "2026-03-16T12:56:53.238602"
+  },
+  {
+    "claim": "Uses deprecated torch.cuda.amp.GradScaler API",
+    "source_file": "train.py",
+    "line_number": 196,
+    "evidence": "193: model.to(device)\n194: \n195: # initialize a GradScaler. If enabled=False scaler is a no-op\n196: scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))\n197: \n198: # optimizer\n199: optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)",
+    "confidence": 0.95,
+    "agent": "TrainingAgent",
+    "category": "training",
+    "finding_id": "F13238",
+    "timestamp": "2026-03-16T12:56:53.238688"
+  },
+  {
+    "claim": "Uses character-level tokenization with 90/10 train/val split",
+    "source_file": "data/shakespeare_char/prepare.py",
+    "line_number": null,
+    "evidence": "Looking at this data preparation script for nanoGPT's Shakespeare dataset, here are my findings with specific evidence and line numbers:\n\n```json\n[\n  {\n    \"claim\": \"Character-level tokenization is im",
+    "confidence": 0.85,
+    "agent": "DataAgent",
+    "category": "data",
+    "finding_id": "F28036",
+    "timestamp": "2026-03-16T12:57:08.036712"
+  },
+  {
+    "claim": "Multiple configs with different dropout values (0.0 vs 0.2)",
+    "source_file": "config/*.py",
+    "line_number": null,
+    "evidence": "Looking at these two nanoGPT configuration files, I can identify several key differences and potential conflicts in training strategies:\n\n```json\n[\n  {\n    \"claim\": \"Dramatically different batch sizes",
+    "confidence": 0.85,
+    "agent": "ConfigAgent",
+    "category": "configuration",
+    "finding_id": "F46416",
+    "timestamp": "2026-03-16T12:57:26.416686"
+  },
+  {
+    "claim": "CONFLICT: GPTConfig default dropout=0.0, but shakespeare config uses dropout=0.2",
+    "source_file": "model.py vs config/train_shakespeare_char.py",
+    "line_number": null,
+    "evidence": "model.py GPTConfig: dropout=0.0 (default) | shakespeare config: dropout=0.2 (override)",
+    "confidence": 0.95,
+    "agent": "ConfigAgent",
+    "category": "configuration",
+    "finding_id": "F46416",
+    "timestamp": "2026-03-16T12:57:26.416704"
+  },
+  {
+    "claim": "Uses exec() for configuration loading - flexible but has security implications",
+    "source_file": "train.py",
+    "line_number": 77,
+    "evidence": "74: compile = True # use PyTorch 2.0 to compile the model to be faster\n75: # -----------------------------------------------------------------------------\n76: config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]\n77: exec(open('configurator.py').read()) # overrides from command line or config file\n78: config = {k: globals()[k] for k in config_keys} # will be useful for logging\n79: # -----------------------------------------------------------------------------\n80: ",
+    "confidence": 0.7,
+    "agent": "CodeQualityAgent",
+    "category": "security",
+    "finding_id": "F64619",
+    "timestamp": "2026-03-16T12:57:44.619521"
+  },
+  {
+    "claim": "bench.py provides benchmarking utilities but requires CUDA",
+    "source_file": "bench.py",
+    "line_number": null,
+    "evidence": "Static analysis only - runtime analysis requires GPU",
+    "confidence": 0.6,
+    "agent": "CodeQualityAgent",
+    "category": "performance",
+    "finding_id": "F64620",
+    "timestamp": "2026-03-16T12:57:44.620832"
+  },
+  {
+    "claim": "Limited type hints in model.py - would improve code maintainability",
+    "source_file": "model.py",
+    "line_number": null,
+    "evidence": "Few type annotations found in function signatures",
+    "confidence": 0.4,
+    "agent": "CodeQualityAgent",
+    "category": "code_quality",
+    "finding_id": "F64621",
+    "timestamp": "2026-03-16T12:57:44.621255"
+  }
+]

--- a/research/nanogpt_research_report.txt
+++ b/research/nanogpt_research_report.txt
@@ -1,0 +1,149 @@
+
+================================================================================
+NANOGPT RESEARCH REPORT
+Generated: 2026-03-16T12:57:57.839850
+================================================================================
+
+EXECUTIVE SUMMARY
+-----------------
+Total Findings: 9
+High Confidence: 6
+Medium Confidence: 2
+Low Confidence (Human Review): 1
+
+Errors Encountered: 1
+Escalations Resolved: 1
+Proposals Generated: 1
+
+ANALYSIS FACTS (Context Preserved Across Agents)
+------------------------------------------------
+- known_issues: ['deprecated GradScaler API'] (source: train.py)
+
+
+KEY FINDINGS (Position-Aware Ordering - Most Important First)
+--------------------------------------------------------------------------------
+
+[F93092] [HIGH] Uses transformer architecture with causal self-attention
+  Source: model.py
+  Evidence: ```json
+[
+  {
+    "claim": "Uses pre-normalization architecture pattern",
+    "line_number": 104,
+    "evidence": "x = x + self.attn(self.ln_1(x)) - L...
+  Agent: ArchitectureAgent | Category: architecture
+
+[F46416] [HIGH] CONFLICT: GPTConfig default dropout=0.0, but shakespeare config uses dropout=0.2
+  Source: model.py vs config/train_shakespeare_char.py
+  Evidence: model.py GPTConfig: dropout=0.0 (default) | shakespeare config: dropout=0.2 (override)...
+  Agent: ConfigAgent | Category: configuration
+
+[F13238] [HIGH] Uses deprecated torch.cuda.amp.GradScaler API
+  Source: train.py (line 196)
+  Evidence: 193: model.to(device)
+194: 
+195: # initialize a GradScaler. If enabled=False scaler is a no-op
+196: scaler = torch.cuda.amp.GradScaler(enabled=(dtype ...
+  Agent: TrainingAgent | Category: training
+
+[F13238] [HIGH] Uses AdamW optimizer with cosine learning rate schedule
+  Source: train.py
+  Evidence: I can only see the header and imports of the file, but I can analyze what's visible. Let me examine the structure and make findings based on the avail...
+  Agent: TrainingAgent | Category: training
+
+[F46416] [HIGH] Multiple configs with different dropout values (0.0 vs 0.2)
+  Source: config/*.py
+  Evidence: Looking at these two nanoGPT configuration files, I can identify several key differences and potential conflicts in training strategies:
+
+```json
+[
+  ...
+  Agent: ConfigAgent | Category: configuration
+
+[F28036] [HIGH] Uses character-level tokenization with 90/10 train/val split
+  Source: data/shakespeare_char/prepare.py
+  Evidence: Looking at this data preparation script for nanoGPT's Shakespeare dataset, here are my findings with specific evidence and line numbers:
+
+```json
+[
+  ...
+  Agent: DataAgent | Category: data
+
+[F64619] [MEDIUM] Uses exec() for configuration loading - flexible but has security implications
+  Source: train.py (line 77)
+  Evidence: 74: compile = True # use PyTorch 2.0 to compile the model to be faster
+75: # -------------------------------------------------------------------------...
+  Agent: CodeQualityAgent | Category: security
+
+[F64620] [MEDIUM] bench.py provides benchmarking utilities but requires CUDA
+  Source: bench.py
+  Evidence: Static analysis only - runtime analysis requires GPU...
+  Agent: CodeQualityAgent | Category: performance
+
+[F64621] [LOW] Limited type hints in model.py - would improve code maintainability
+  Source: model.py
+  Evidence: Few type annotations found in function signatures...
+  Agent: CodeQualityAgent | Category: code_quality
+  ⚠️  FLAGGED FOR HUMAN REVIEW (confidence 0.4)
+
+
+PROPOSALS (Autoresearch-Style Modifications)
+--------------------------------------------------------------------------------
+
+[P77839] Replace deprecated GradScaler API
+  Type: bugfix | Confidence: 0.90
+  Target: train.py
+  Description: Update torch.cuda.amp.GradScaler to modern API
+  Expected Impact: Fix deprecation warning, ensure PyTorch 2.x compatibility
+  Supporting Findings: 
+
+
+ERRORS & PARTIAL RESULTS (Error Propagation)
+--------------------------------------------------------------------------------
+
+[E64620] environment_constraint
+  Attempted: Analyze bench.py runtime performance characteristics
+  Partial Results: {
+  "file_structure": "parsed",
+  "functions_identified": [
+    "benchmark_fn"
+  ],
+  "static_analysis": "completed"
+}
+  Alternatives: Static analysis only - no runtime benchmarks, Analyze configuration and setup code, Document CUDA requirement for future analysis
+  Should Retry: False
+
+
+ESCALATIONS RESOLVED (Ambiguity Handling)
+--------------------------------------------------------------------------------
+
+[ESC60061] exec() usage in configurator - security risk vs intentional design
+  Agent: CodeQualityAgent
+  Options Considered: Flag as security vulnerability - recommend safer config loading, Document as intentional design - note security implications, Propose hybrid approach - exec() with sandboxing
+  Recommended Action: Document as intentional design with security caveat
+
+
+COVERAGE ANALYSIS (Uncertainty & Gaps)
+--------------------------------------------------------------------------------
+✓ ANALYZED:
+  - model.py (architecture, attention mechanism, initialization)
+  - train.py (training loop, optimizer, DDP support)
+  - configurator.py (config system)
+  - config/*.py (hyperparameter choices)
+  - data/shakespeare_char/prepare.py (data pipeline)
+
+✗ INCOMPLETE:
+  - bench.py: GPU performance analysis (no CUDA available)
+  - Jupyter notebooks: scaling_laws.ipynb, transformer_sizing.ipynb
+  - Runtime behavior: No execution traces available
+  - GPU-specific optimizations: Environment constraint
+
+
+HUMAN REVIEW QUEUE
+--------------------------------------------------------------------------------
+- [F64621] Limited type hints in model.py - would improve code maintainability (confidence: 0.4)
+
+
+================================================================================
+END OF REPORT
+================================================================================

--- a/research/proposals.json
+++ b/research/proposals.json
@@ -1,0 +1,12 @@
+[
+  {
+    "title": "Replace deprecated GradScaler API",
+    "description": "Update torch.cuda.amp.GradScaler to modern API",
+    "target_file": "train.py",
+    "modification_type": "bugfix",
+    "expected_impact": "Fix deprecation warning, ensure PyTorch 2.x compatibility",
+    "confidence": 0.9,
+    "supporting_findings": [],
+    "proposal_id": "P77839"
+  }
+]

--- a/research/state_manifest.json
+++ b/research/state_manifest.json
@@ -1,0 +1,23 @@
+{
+  "completed_agents": [
+    "ArchitectureAgent",
+    "TrainingAgent",
+    "DataAgent",
+    "ConfigAgent",
+    "CodeQualityAgent"
+  ],
+  "pending_agents": [],
+  "findings_count": 9,
+  "errors_count": 1,
+  "escalations_count": 1,
+  "timestamp": "2026-03-16T12:57:57.841648",
+  "analysis_facts": {
+    "known_issues": {
+      "value": [
+        "deprecated GradScaler API"
+      ],
+      "source": "train.py",
+      "timestamp": "2026-03-16T12:56:53.238693"
+    }
+  }
+}

--- a/train.py
+++ b/train.py
@@ -193,7 +193,7 @@ if block_size < model.config.block_size:
 model.to(device)
 
 # initialize a GradScaler. If enabled=False scaler is a no-op
-scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
+scaler = torch.amp.GradScaler('cuda', enabled=(dtype == 'float16'))
 
 # optimizer
 optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)


### PR DESCRIPTION
## Summary
- Replace `torch.cuda.amp.GradScaler` with `torch.amp.GradScaler('cuda')` to fix deprecation warning in PyTorch 2.x
- This issue was **automatically identified** by the Domain 5 multi-agent research system (finding F13238, high confidence) and proposed as modification P77839

## How This Was Found
The Domain 5 capstone runs an **autoresearch-style multi-agent system** that analyzes the nanoGPT codebase:
1. **TrainingAgent** analyzed `train.py` and flagged the deprecated API at line 196
2. **ProposalGenerator** created proposal P77839 with 0.90 confidence
3. This PR implements that proposal

## What Changed
```python
# Before (deprecated in PyTorch 2.x)
scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))

# After (modern API)
scaler = torch.amp.GradScaler('cuda', enabled=(dtype == 'float16'))
```

## Test Plan
- [ ] Verify CI/CD pipeline triggers (test.yml, lint.yml, review.yml)
- [ ] Check that Claude Code Review workflow posts findings
- [ ] Confirm PyTorch 2.x compatibility

## Exam Concepts Demonstrated
- **Domain 3.6**: CI/CD integration with GitHub Actions
- **Domain 5.5**: Human review of AI-proposed changes
- **Domain 5.6**: Provenance tracking (finding → proposal → PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)