### PR TITLE
feat: add optional Attention Residuals (Block AttnRes) architecture

### DIFF
--- a/config/train_shakespeare_char_attnres.py
+++ b/config/train_shakespeare_char_attnres.py
@@ -1,0 +1,38 @@
+# train a miniature character-level shakespeare model with Attention Residuals
+# compare with train_shakespeare_char.py to see the effect of AttnRes
+
+out_dir = 'out-shakespeare-char-attnres'
+eval_interval = 250
+eval_iters = 200
+log_interval = 10
+
+always_save_checkpoint = False
+
+wandb_log = False
+wandb_project = 'shakespeare-char'
+wandb_run_name = 'mini-gpt-attnres'
+
+dataset = 'shakespeare_char'
+gradient_accumulation_steps = 1
+batch_size = 64
+block_size = 256
+
+# baby GPT model with Attention Residuals
+n_layer = 6
+n_head = 6
+n_embd = 384
+dropout = 0.2
+attn_res = True
+attn_res_block_size = 4  # 2 transformer layers per block
+
+learning_rate = 1e-3
+max_iters = 5000
+lr_decay_iters = 5000
+min_lr = 1e-4
+beta2 = 0.99
+
+warmup_iters = 100
+
+# AttnRes uses dynamic list ops that may cause torch.compile recompilation;
+# set compile = False if you encounter issues
+# compile = False

--- a/model.py
+++ b/model.py
@@ -1,10 +1,13 @@
 """
 Full definition of a GPT Language Model, all of it in this single file.
+Optionally supports Attention Residuals (AttnRes) from MoonshotAI.
 References:
 1) the official GPT-2 TensorFlow implementation released by OpenAI:
 https://github.com/openai/gpt-2/blob/master/src/model.py
 2) huggingface/transformers PyTorch implementation:
 https://github.com/huggingface/transformers/blob/main/src/transformers/models/gpt2/modeling_gpt2.py
+3) Attention Residuals (AttnRes):
+https://github.com/MoonshotAI/Attention-Residuals
 """
 
 import math
@@ -25,6 +28,33 @@ class LayerNorm(nn.Module):
 
     def forward(self, input):
         return F.layer_norm(input, self.weight.shape, self.weight, self.bias, 1e-5)
+
+class RMSNorm(nn.Module):
+    """RMSNorm used in Attention Residuals for normalizing keys."""
+
+    def __init__(self, ndim, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(ndim))
+        self.eps = eps
+
+    def forward(self, x):
+        rms = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+        return x * rms * self.weight
+
+def block_attn_res(blocks, partial_block, proj, norm):
+    """
+    Inter-block attention: attend over block reps + current partial sum.
+    blocks: list of N tensors of shape [B, T, D] (completed block representations)
+    partial_block: [B, T, D] (intra-block partial sum)
+    proj: nn.Linear(D, 1, bias=False) — learned pseudo-query
+    norm: RMSNorm — applied to keys
+    Returns: [B, T, D] — weighted combination of all representations
+    """
+    V = torch.stack(blocks + [partial_block])  # [N+1, B, T, D]
+    K = norm(V)
+    logits = torch.einsum('d, n b t d -> n b t', proj.weight.squeeze(), K)
+    h = torch.einsum('n b t, n b t d -> b t d', logits.softmax(0), V)
+    return h
 
 class CausalSelfAttention(nn.Module):
 
@@ -93,17 +123,54 @@ class MLP(nn.Module):
 
 class Block(nn.Module):
 
-    def __init__(self, config):
+    def __init__(self, config, layer_idx=0):
         super().__init__()
         self.ln_1 = LayerNorm(config.n_embd, bias=config.bias)
         self.attn = CausalSelfAttention(config)
         self.ln_2 = LayerNorm(config.n_embd, bias=config.bias)
         self.mlp = MLP(config)
 
-    def forward(self, x):
-        x = x + self.attn(self.ln_1(x))
-        x = x + self.mlp(self.ln_2(x))
-        return x
+        # Attention Residuals (optional)
+        self.use_attn_res = config.attn_res
+        if self.use_attn_res:
+            assert config.attn_res_block_size >= 2 and config.attn_res_block_size % 2 == 0, \
+                f"attn_res_block_size must be even and >= 2, got {config.attn_res_block_size}"
+            self.layer_idx = layer_idx
+            self.ar_block_size = config.attn_res_block_size
+            self.attn_res_proj = nn.Linear(config.n_embd, 1, bias=False)
+            self.attn_res_norm = RMSNorm(config.n_embd)
+            self.mlp_res_proj = nn.Linear(config.n_embd, 1, bias=False)
+            self.mlp_res_norm = RMSNorm(config.n_embd)
+
+    def forward(self, x, blocks=None, partial_block=None):
+        if not self.use_attn_res:
+            # original nanoGPT path — zero overhead
+            x = x + self.attn(self.ln_1(x))
+            x = x + self.mlp(self.ln_2(x))
+            return x
+
+        # --- Block AttnRes path ---
+        # attend over block reps before self-attention
+        h = block_attn_res(blocks, partial_block, self.attn_res_proj, self.attn_res_norm)
+
+        # check block boundary: start a new block
+        layers_per_block = self.ar_block_size // 2
+        if self.layer_idx % layers_per_block == 0 and self.layer_idx > 0:
+            blocks = blocks + [partial_block]
+            partial_block = None
+
+        # self-attention
+        attn_out = self.attn(self.ln_1(h))
+        partial_block = partial_block + attn_out if partial_block is not None else attn_out
+
+        # attend over block reps before MLP
+        h = block_attn_res(blocks, partial_block, self.mlp_res_proj, self.mlp_res_norm)
+
+        # MLP
+        mlp_out = self.mlp(self.ln_2(h))
+        partial_block = partial_block + mlp_out
+
+        return blocks, partial_block
 
 @dataclass
 class GPTConfig:
@@ -114,6 +181,8 @@ class GPTConfig:
     n_embd: int = 768
     dropout: float = 0.0
     bias: bool = True # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
+    attn_res: bool = False # True: use Attention Residuals instead of standard residual connections
+    attn_res_block_size: int = 4 # number of sub-layers per block (attn+mlp each count as 1, so 4 = 2 transformer layers per block)
 
 class GPT(nn.Module):
 
@@ -127,7 +196,7 @@ class GPT(nn.Module):
             wte = nn.Embedding(config.vocab_size, config.n_embd),
             wpe = nn.Embedding(config.block_size, config.n_embd),
             drop = nn.Dropout(config.dropout),
-            h = nn.ModuleList([Block(config) for _ in range(config.n_layer)]),
+            h = nn.ModuleList([Block(config, layer_idx=i) for i in range(config.n_layer)]),
             ln_f = LayerNorm(config.n_embd, bias=config.bias),
         ))
         self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
@@ -177,8 +246,19 @@ class GPT(nn.Module):
         tok_emb = self.transformer.wte(idx) # token embeddings of shape (b, t, n_embd)
         pos_emb = self.transformer.wpe(pos) # position embeddings of shape (t, n_embd)
         x = self.transformer.drop(tok_emb + pos_emb)
-        for block in self.transformer.h:
-            x = block(x)
+
+        if not self.config.attn_res:
+            # original nanoGPT path
+            for block in self.transformer.h:
+                x = block(x)
+        else:
+            # Attention Residuals path: maintain block reps and partial_block
+            blocks = [x]  # token embedding is the first block rep
+            partial_block = x
+            for block in self.transformer.h:
+                blocks, partial_block = block(None, blocks, partial_block)
+            x = partial_block
+
         x = self.transformer.ln_f(x)
 
         if targets is not None:

--- a/train.py
+++ b/train.py
@@ -54,6 +54,8 @@ n_head = 12
 n_embd = 768
 dropout = 0.0 # for pretraining 0 is good, for finetuning try 0.1+
 bias = False # do we use bias inside LayerNorm and Linear layers?
+attn_res = False # use Attention Residuals (AttnRes) instead of standard residual connections
+attn_res_block_size = 4 # AttnRes block size: number of sub-layers per block (4 = 2 transformer layers)
 # adamw optimizer
 learning_rate = 6e-4 # max learning rate
 max_iters = 600000 # total number of training iterations
@@ -145,7 +147,8 @@ if os.path.exists(meta_path):
 
 # model init
 model_args = dict(n_layer=n_layer, n_head=n_head, n_embd=n_embd, block_size=block_size,
-                  bias=bias, vocab_size=None, dropout=dropout) # start with model_args from command line
+                  bias=bias, vocab_size=None, dropout=dropout,
+                  attn_res=attn_res, attn_res_block_size=attn_res_block_size)
 if init_from == 'scratch':
     # init a new model from scratch
     print("Initializing a new model from scratch")
@@ -163,8 +166,10 @@ elif init_from == 'resume':
     checkpoint_model_args = checkpoint['model_args']
     # force these config attributes to be equal otherwise we can't even resume training
     # the rest of the attributes (e.g. dropout) can stay as desired from command line
-    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:
-        model_args[k] = checkpoint_model_args[k]
+    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size',
+              'attn_res', 'attn_res_block_size']:
+        if k in checkpoint_model_args:
+            model_args[k] = checkpoint_model_args[k]
     # create the model
     gptconf = GPTConfig(**model_args)
     model = GPT(gptconf)


### PR DESCRIPTION
## Summary

Integrate **Block Attention Residuals** ([MoonshotAI/Attention-Residuals](https://github.com/MoonshotAI/Attention-Residuals)) into nanoGPT as an optional, drop-in architecture. When disabled (default), the code path is identical to the original nanoGPT with zero overhead.

AttnRes replaces fixed-weight residual connections (`x = x + sublayer(x)`) with learned, input-dependent attention over depth. Each layer attends to prior block representations via a softmax-weighted combination computed with a learnable pseudo-query vector per sub-layer.

## Changes

### model.py (+92/-8)
- **`RMSNorm`**: new class for normalizing keys in depth-attention
- **`block_attn_res()`**: core mechanism — stack block reps as V, RMSNorm as K, pseudo-query einsum → softmax over depth → weighted sum
- **`Block.__init__`**: optionally creates 4 AttnRes modules per layer (2 `nn.Linear(D,1)` projections + 2 `RMSNorm`)
- **`Block.forward`**: when `attn_res=False`, original path unchanged; when `True`, block-boundary-aware depth attention replaces standard residual accumulation
- **`GPT.forward`**: threads `blocks` list and `partial_block` state through layers
- **`GPTConfig`**: new fields `attn_res` (bool, default `False`), `attn_res_block_size` (int, default `4`)
- **Validation**: asserts `attn_res_block_size` is even and ≥ 2

### train.py (+8/-3)
- Add `attn_res` and `attn_res_block_size` config variables
- Include new fields in `model_args` dict
- Backward-compatible checkpoint resume (`if k in checkpoint_model_args` guard)

### config/train_shakespeare_char_attnres.py (new)
- Example config for training with AttnRes enabled

## Parameter overhead
~0.5% extra parameters (only pseudo-query projections + RMSNorm weights per layer)

## Usage
```bash
# Standard nanoGPT (unchanged)
python train.py config/train_shakespeare_char.py

# With Attention Residuals
python train.py config/train_shakespeare_char.py --attn_res=True --attn_res_block_size=4
```

## Design decisions
- `attn_res=False` follows the exact original code path — no performance penalty
- Block boundary logic matches the paper's pseudocode: attend first, then check boundary
- `blocks` list initialized with token embedding per paper ("blocks already include token embedding")
- `layer_idx > 0` guard prevents duplicate embedding entry at layer 0
- Dynamic `blocks` list growth may cause `torch.compile` recompilation on some backends — noted in example config

## Test plan
- [x] Forward + backward pass works for both `attn_res=False` and `True`
- [x] Gradient flow verified for all AttnRes parameters
- [x] Generation (`model.generate()`) works for both modes
- [x] Validation rejects invalid `attn_res_block_size` (odd, 0, 1)
- [x] Various `attn_res_block_size` values (2, 4, 6) tested
- [x] Old checkpoint resume compatibility (missing AttnRes fields gracefully default)
- [x] `torch.compile` tested with `eager` and `aot_eager` backends (PyTorch 2.10)

## Reference
https://github.com/MoonshotAI/Attention-Residuals