### PR TITLE
fix: properly handle MPS device type for Apple Silicon training

### DIFF
--- a/train.py
+++ b/train.py
@@ -106,7 +106,7 @@ if master_process:
 torch.manual_seed(1337 + seed_offset)
 torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
 torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
-device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast
+device_type = 'cuda' if 'cuda' in device else ('mps' if 'mps' in device else 'cpu') # for later use in torch.autocast
 # note: float16 data type will automatically use a GradScaler
 ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
 ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
@@ -123,7 +123,7 @@ def get_batch(split):
     ix = torch.randint(len(data) - block_size, (batch_size,))
     x = torch.stack([torch.from_numpy((data[i:i+block_size]).astype(np.int64)) for i in ix])
     y = torch.stack([torch.from_numpy((data[i+1:i+1+block_size]).astype(np.int64)) for i in ix])
-    if device_type == 'cuda':
+    if device_type in ('cuda', 'mps'):
         # pin arrays x,y, which allows us to move them to GPU asynchronously (non_blocking=True)
         x, y = x.pin_memory().to(device, non_blocking=True), y.pin_memory().to(device, non_blocking=True)
     else:
@@ -193,7 +193,7 @@ if block_size < model.config.block_size:
 model.to(device)
 
 # initialize a GradScaler. If enabled=False scaler is a no-op
-scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
+scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16' and device_type == 'cuda'))
 
 # optimizer
 optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)


### PR DESCRIPTION
## Summary

Fixes #654 — training with `device='mps'` (Apple Silicon) crashes or silently misbehaves because `device_type` detection only distinguishes between `'cuda'` and `'cpu'`, treating MPS as CPU.

### The Bug (3 cascading issues)

1. **`device_type` misclassifies MPS as CPU** (line 109): `'cuda' in 'mps'` is `False` so `device_type = 'cpu'`
2. **`torch.amp.autocast` is skipped** (line 112): CPU path uses `nullcontext()`, so float16 autocast never activates despite `dtype='float16'` being set
3. **`GradScaler` is enabled but CUDA-only** (line 196): `dtype == 'float16'` is `True` (since `torch.cuda.is_bf16_supported()` returns `False` on MPS), so `GradScaler(enabled=True)` is created — but `torch.cuda.amp.GradScaler` internally operates on CUDA tensors, causing runtime errors on MPS

### The Fix (3 lines)

- **Line 109**: Detect `'mps'` as a distinct device type: `'cuda' if 'cuda' in device else ('mps' if 'mps' in device else 'cpu')`
- **Line 126**: Enable `pin_memory()` + `non_blocking` transfer for MPS (supported in PyTorch 2.0+)
- **Line 196**: Restrict `GradScaler` to CUDA only: `enabled=(dtype == 'float16' and device_type == 'cuda')`

### Why This Works

- `torch.amp.autocast(device_type='mps')` is supported since PyTorch 2.0
- `GradScaler` is CUDA-specific (prevents float16 gradient underflow). MPS float16 does not need it — disabling is the correct behavior
- `pin_memory()` works on MPS for async data transfer

### Testing

Verified the fix logic against PyTorch MPS documentation. The existing autocast path (`torch.amp.autocast`) already supports `device_type='mps'`, so no additional code is needed beyond correct device detection.