### PR TITLE
Fix deprecated torch.cuda.amp.GradScaler warning

### DIFF
--- a/train.py
+++ b/train.py
@@ -193,7 +193,7 @@ if block_size < model.config.block_size:
 model.to(device)
 
 # initialize a GradScaler. If enabled=False scaler is a no-op
-scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
+scaler = torch.amp.GradScaler('cuda', enabled=(dtype == 'float16'))
 
 # optimizer
 optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)


### PR DESCRIPTION
## Summary
- Replace deprecated `torch.cuda.amp.GradScaler(enabled=...)` with `torch.amp.GradScaler('cuda', enabled=...)` on line 196
- Silences the `FutureWarning` that appears on recent PyTorch versions
- Consistent with the already-updated `torch.amp.autocast` call on line 112

Addresses #704.

## Test plan
- [x] `torch.amp.GradScaler` is the recommended replacement per [PyTorch docs](https://pytorch.org/docs/stable/amp.html#torch.amp.GradScaler)
- [x] Verified the `autocast` call already uses the new `torch.amp.autocast` API