### PR TITLE
Fix file handle leak in configurator.py

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -24,8 +24,9 @@ for arg in sys.argv[1:]:
         config_file = arg
         print(f"Overriding config with {config_file}:")
         with open(config_file) as f:
-            print(f.read())
-        exec(open(config_file).read())
+            config_content = f.read()
+        print(config_content)
+        exec(config_content)
     else:
         # assume it's a --key=value argument
         assert arg.startswith('--')


### PR DESCRIPTION
## Summary
- The config file in `configurator.py` was being opened twice: once with a `with` statement (line 26-27) to print its contents, and again with a bare `open()` call (line 28) for `exec()`. The second `open()` creates a file handle that is never explicitly closed, leaking the file descriptor.
- Fix by reading the file content once into a variable and reusing it for both `print()` and `exec()`, eliminating the redundant `open()` and the resource leak.

## Test plan
- [x] Verified that `configurator.py` still correctly reads and executes config file overrides
- [x] Verified that config content is still printed to stdout before execution
- [x] No behavioral change -- only eliminates the leaked file handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)