### PR TITLE
Add explicit UTF-8 encoding in shakespeare_char/prepare.py

### DIFF
--- a/data/shakespeare_char/prepare.py
+++ b/data/shakespeare_char/prepare.py
@@ -13,10 +13,10 @@ import numpy as np
 input_file_path = os.path.join(os.path.dirname(__file__), 'input.txt')
 if not os.path.exists(input_file_path):
     data_url = 'https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt'
-    with open(input_file_path, 'w') as f:
+    with open(input_file_path, 'w', encoding='utf-8') as f:
         f.write(requests.get(data_url).text)
 
-with open(input_file_path, 'r') as f:
+with open(input_file_path, 'r', encoding='utf-8') as f:
     data = f.read()
 print(f"length of dataset in characters: {len(data):,}")
 


### PR DESCRIPTION
## Summary
- Add `encoding='utf-8'` to the `open()` calls in `data/shakespeare_char/prepare.py` for writing and reading `input.txt`
- Without an explicit encoding, Python uses the platform default, which on Windows defaults to the system locale encoding (e.g. cp1252) and can cause encoding errors or silent data corruption
- This makes `shakespeare_char/prepare.py` consistent with `data/shakespeare/prepare.py`, which already specifies `encoding='utf-8'`

## Test plan
- [x] Verified the fix matches the pattern in `data/shakespeare/prepare.py`
- [x] No behavioral change on Linux/macOS (where UTF-8 is typically the default)
- [x] Fixes potential encoding issues on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)