### PR TITLE
Fix deprecated torch.cuda.amp.GradScaler API

### DIFF
--- a/train.py
+++ b/train.py
@@ -193,7 +193,7 @@ if block_size < model.config.block_size:
 model.to(device)
 
 # initialize a GradScaler. If enabled=False scaler is a no-op
-scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
+scaler = torch.amp.GradScaler(device_type, enabled=(dtype == 'float16'))
 
 # optimizer
 optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)


### PR DESCRIPTION
## Summary
- Fixes #635 (also addresses #704 which is a duplicate)
- Replaces deprecated `torch.cuda.amp.GradScaler(enabled=...)` with `torch.amp.GradScaler(device_type, enabled=...)` in `train.py`
- This resolves the `FutureWarning` emitted by recent PyTorch versions and aligns the GradScaler initialization with the already-updated `torch.amp.autocast` call on line 112

## Details
PyTorch has deprecated `torch.cuda.amp.GradScaler` in favor of `torch.amp.GradScaler`, which accepts a `device_type` argument. The new API is device-agnostic and consistent with the modern `torch.amp.autocast` already used in this file.

## Test plan
- [ ] Run `python train.py config/train_shakespeare_char.py` and verify no FutureWarning is emitted
- [ ] Confirm training proceeds identically (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)