### PR TITLE
week3: add configurable module experiments and toy MoE

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,3 +17,6 @@ compile: false
 wandb_log: false
 wandb_project: nanogpt
 wandb_run_name: nanogpt-run
+wandb_group: week3
+wandb_tags: []
+wandb_notes: ""

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,19 @@
+defaults:
+  - model: nanogpt_small
+  - data: shakespeare
+  - optim: adamw
+  - _self_
+
+seed: 42
+out_dir: /root/autodl-tmp/ckpt
+eval_interval: 9999
+eval_iters: 200
+log_interval: 1
+eval_only: false
+always_save_checkpoint: false
+checkpoint_interval: 500
+init_from: scratch
+compile: false
+wandb_log: false
+wandb_project: nanogpt
+wandb_run_name: nanogpt-run

--- a/config/data/shakespeare.yaml
+++ b/config/data/shakespeare.yaml
@@ -1,0 +1,3 @@
+dataset: shakespeare_char
+batch_size: 8
+gradient_accumulation_steps: 1

--- a/config/model/nanogpt_small.yaml
+++ b/config/model/nanogpt_small.yaml
@@ -1,0 +1,6 @@
+n_layer: 4
+n_head: 4
+n_embd: 128
+block_size: 64
+dropout: 0.0
+bias: false

--- a/config/model/nanogpt_small.yaml
+++ b/config/model/nanogpt_small.yaml
@@ -4,3 +4,9 @@ n_embd: 128
 block_size: 64
 dropout: 0.0
 bias: false
+activation: gelu
+norm_position: pre
+use_moe: false
+moe_n_experts: 4
+moe_top_k: 2
+moe_aux_loss_weight: 0.01

--- a/config/optim/adamw.yaml
+++ b/config/optim/adamw.yaml
@@ -1,3 +1,4 @@
+name: adamw
 learning_rate: 6e-4
 max_iters: 500
 weight_decay: 0.1
@@ -8,3 +9,4 @@ decay_lr: true
 warmup_iters: 100
 lr_decay_iters: 500
 min_lr: 6e-5
+momentum: 0.9

--- a/config/optim/adamw.yaml
+++ b/config/optim/adamw.yaml
@@ -1,0 +1,10 @@
+learning_rate: 6e-4
+max_iters: 500
+weight_decay: 0.1
+beta1: 0.9
+beta2: 0.95
+grad_clip: 1.0
+decay_lr: true
+warmup_iters: 100
+lr_decay_iters: 500
+min_lr: 6e-5

--- a/day4_results.md
+++ b/day4_results.md
@@ -1,0 +1,50 @@
+# Day 4: Standard Reproducibility — GPT-2 Fine-tuning on WikiText-2
+
+## 实验配置
+
+| 参数 | 值 |
+|------|-----|
+| 模型 | GPT-2 (124M) |
+| 数据集 | wikitext-2-raw-v1 |
+| Epochs | 1 |
+| Learning rate | 5e-5 |
+| Warmup steps | 100 |
+| Batch size | 4 |
+| GPU | NVIDIA GeForce RTX 5090 (32 GB) |
+
+---
+
+## 实验结果
+
+| Run | Seed | Train Loss | Eval Loss | Perplexity | 训练时长 | wandb URL |
+|-----|------|-----------|-----------|------------|---------|-----------|
+| gpt2-wt2-seed42   | 42   | 3.2642 | 3.0712 | 21.57 | 1:04 | https://wandb.ai/grace2056320586-guangdong-technionisrael-institute-of-te/nanogpt/runs/pelqc04i |
+| gpt2-wt2-seed123  | 123  | 3.2654 | 3.0726 | 21.60 | 1:05 | https://wandb.ai/grace2056320586-guangdong-technionisrael-institute-of-te/nanogpt/runs/hejr4279 |
+| gpt2-wt2-seed2024 | 2024 | 3.2656 | 3.0717 | 21.58 | 1:05 | https://wandb.ai/grace2056320586-guangdong-technionisrael-institute-of-te/nanogpt/runs/x2s6qoz2 |
+| **均值** | — | **3.2651** | **3.0718** | **21.58** | — | — |
+| **标准差** | — | **0.0006** | **0.0006** | **0.013** | — | — |
+
+---
+
+## 与官方数字对比
+
+| 来源 | PPL |
+|------|-----|
+| GPT-2 论文（zero-shot，wikitext-2） | ~29.4 |
+| 本次实验（fine-tuned，1 epoch） | **21.58** |
+| 差值 | -7.8 |
+
+### 分析
+
+1. **fine-tune vs zero-shot**：本次实验对 GPT-2 在 wikitext-2 上做了 1 epoch 的监督微调，而论文报告的 29.4 是**零样本（zero-shot）**结果，即直接用预训练模型不做任何微调。因此 PPL 从 29.4 降到 21.58 是合理的——模型见过了训练集的文本，预测能力自然提升。
+
+2. **复现性**：3 个不同 seed（42、123、2024）的 PPL 分别为 21.57 / 21.60 / 21.58，标准差仅 0.013，说明训练结果**高度稳定**，随机因素（权重初始化、数据 shuffle）对最终指标影响极小。
+
+3. **结果是否合理**：目标区间为 PPL 20~30，本次结果 21.58 完全符合预期，验证了实验流程正确。
+
+---
+
+## 异常记录
+
+- `--overwrite_output_dir` 参数在新版 transformers 中已移除，训练脚本中去掉该参数后正常运行。
+- 服务器无法直接访问 GitHub（443 端口超时），模型/数据集通过 `HF_ENDPOINT=https://hf-mirror.com` 镜像下载，已缓存在 `/root/autodl-tmp/cache/huggingface`。

--- a/model.py
+++ b/model.py
@@ -79,17 +79,62 @@ class MLP(nn.Module):
 
     def __init__(self, config):
         super().__init__()
-        self.c_fc    = nn.Linear(config.n_embd, 4 * config.n_embd, bias=config.bias)
-        self.gelu    = nn.GELU()
-        self.c_proj  = nn.Linear(4 * config.n_embd, config.n_embd, bias=config.bias)
+        self.c_fc = nn.Linear(config.n_embd, 4 * config.n_embd, bias=config.bias)
+        self.activation_name = config.activation
+        if self.activation_name == "gelu":
+            self.activation = nn.GELU()
+        elif self.activation_name == "relu":
+            self.activation = nn.ReLU()
+        elif self.activation_name == "silu":
+            self.activation = nn.SiLU()
+        else:
+            raise ValueError(f"unknown activation: {self.activation_name}")
+        self.c_proj = nn.Linear(4 * config.n_embd, config.n_embd, bias=config.bias)
         self.dropout = nn.Dropout(config.dropout)
 
     def forward(self, x):
         x = self.c_fc(x)
-        x = self.gelu(x)
+        x = self.activation(x)
         x = self.c_proj(x)
         x = self.dropout(x)
         return x
+
+
+def load_balancing_loss(gate_probs, topk_idx, n_experts):
+    """Switch-style auxiliary loss that encourages uniform expert usage."""
+    one_hot = F.one_hot(topk_idx, num_classes=n_experts).float()
+    f_i = one_hot.sum(dim=(0, 1, 2)) / one_hot.sum().clamp_min(1.0)
+    p_i = gate_probs.mean(dim=(0, 1))
+    return n_experts * (f_i * p_i).sum()
+
+
+class ToyMoEMLP(nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+        self.n_experts = config.moe_n_experts
+        self.top_k = config.moe_top_k
+        if self.top_k < 1 or self.top_k > self.n_experts:
+            raise ValueError(f"moe_top_k must be in [1, {self.n_experts}], got {self.top_k}")
+        self.gate = nn.Linear(config.n_embd, self.n_experts, bias=False)
+        self.experts = nn.ModuleList([MLP(config) for _ in range(self.n_experts)])
+        self.aux_loss = torch.tensor(0.0)
+
+    def forward(self, x):
+        gate_logits = self.gate(x)
+        gate_probs = F.softmax(gate_logits, dim=-1)
+        topk_w, topk_i = gate_probs.topk(self.top_k, dim=-1)
+        topk_w = topk_w / topk_w.sum(dim=-1, keepdim=True).clamp_min(1e-9)
+
+        out = torch.zeros_like(x)
+        for eid in range(self.n_experts):
+            weight = (topk_w * (topk_i == eid)).sum(dim=-1, keepdim=True)
+            if torch.count_nonzero(weight) == 0:
+                continue
+            out = out + self.experts[eid](x) * weight
+
+        self.aux_loss = load_balancing_loss(gate_probs, topk_i, self.n_experts)
+        return out
 
 class Block(nn.Module):
 
@@ -98,11 +143,18 @@ class Block(nn.Module):
         self.ln_1 = LayerNorm(config.n_embd, bias=config.bias)
         self.attn = CausalSelfAttention(config)
         self.ln_2 = LayerNorm(config.n_embd, bias=config.bias)
-        self.mlp = MLP(config)
+        self.mlp = ToyMoEMLP(config) if config.use_moe else MLP(config)
+        self.norm_position = config.norm_position
 
     def forward(self, x):
-        x = x + self.attn(self.ln_1(x))
-        x = x + self.mlp(self.ln_2(x))
+        if self.norm_position == "pre":
+            x = x + self.attn(self.ln_1(x))
+            x = x + self.mlp(self.ln_2(x))
+        elif self.norm_position == "post":
+            x = self.ln_1(x + self.attn(x))
+            x = self.ln_2(x + self.mlp(x))
+        else:
+            raise ValueError(f"unknown norm_position: {self.norm_position}")
         return x
 
 @dataclass
@@ -114,6 +166,12 @@ class GPTConfig:
     n_embd: int = 768
     dropout: float = 0.0
     bias: bool = True # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
+    activation: str = "gelu"
+    norm_position: str = "pre"
+    use_moe: bool = False
+    moe_n_experts: int = 4
+    moe_top_k: int = 2
+    moe_aux_loss_weight: float = 0.01
 
 class GPT(nn.Module):
 
@@ -122,6 +180,8 @@ class GPT(nn.Module):
         assert config.vocab_size is not None
         assert config.block_size is not None
         self.config = config
+        self.last_ce_loss = None
+        self.last_aux_loss = torch.tensor(0.0)
 
         self.transformer = nn.ModuleDict(dict(
             wte = nn.Embedding(config.vocab_size, config.n_embd),
@@ -184,13 +244,27 @@ class GPT(nn.Module):
         if targets is not None:
             # if we are given some desired targets also calculate the loss
             logits = self.lm_head(x)
-            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
+            ce_loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
+            aux_loss = self.get_moe_aux_loss()
+            loss = ce_loss + self.config.moe_aux_loss_weight * aux_loss
+            self.last_ce_loss = ce_loss.detach()
+            self.last_aux_loss = aux_loss.detach()
         else:
             # inference-time mini-optimization: only forward the lm_head on the very last position
             logits = self.lm_head(x[:, [-1], :]) # note: using list [-1] to preserve the time dim
             loss = None
 
         return logits, loss
+
+    def get_moe_aux_loss(self):
+        losses = []
+        for block in self.transformer.h:
+            aux_loss = getattr(block.mlp, "aux_loss", None)
+            if aux_loss is not None:
+                losses.append(aux_loss)
+        if not losses:
+            return torch.tensor(0.0, device=self.lm_head.weight.device)
+        return torch.stack(losses).mean()
 
     def crop_block_size(self, block_size):
         # model surgery to decrease the block size if necessary
@@ -260,7 +334,7 @@ class GPT(nn.Module):
 
         return model
 
-    def configure_optimizers(self, weight_decay, learning_rate, betas, device_type):
+    def configure_optimizers(self, weight_decay, learning_rate, betas, device_type, optimizer_name="adamw", momentum=0.9):
         # start with all of the candidate parameters
         param_dict = {pn: p for pn, p in self.named_parameters()}
         # filter out those that do not require grad
@@ -277,12 +351,18 @@ class GPT(nn.Module):
         num_nodecay_params = sum(p.numel() for p in nodecay_params)
         print(f"num decayed parameter tensors: {len(decay_params)}, with {num_decay_params:,} parameters")
         print(f"num non-decayed parameter tensors: {len(nodecay_params)}, with {num_nodecay_params:,} parameters")
-        # Create AdamW optimizer and use the fused version if it is available
-        fused_available = 'fused' in inspect.signature(torch.optim.AdamW).parameters
-        use_fused = fused_available and device_type == 'cuda'
-        extra_args = dict(fused=True) if use_fused else dict()
-        optimizer = torch.optim.AdamW(optim_groups, lr=learning_rate, betas=betas, **extra_args)
-        print(f"using fused AdamW: {use_fused}")
+        if optimizer_name == "adamw":
+            # Create AdamW optimizer and use the fused version if it is available
+            fused_available = 'fused' in inspect.signature(torch.optim.AdamW).parameters
+            use_fused = fused_available and device_type == 'cuda'
+            extra_args = dict(fused=True) if use_fused else dict()
+            optimizer = torch.optim.AdamW(optim_groups, lr=learning_rate, betas=betas, **extra_args)
+            print(f"using fused AdamW: {use_fused}")
+        elif optimizer_name == "sgd":
+            optimizer = torch.optim.SGD(optim_groups, lr=learning_rate, momentum=momentum)
+            print(f"using SGD with momentum={momentum}")
+        else:
+            raise ValueError(f"unknown optimizer: {optimizer_name}")
 
         return optimizer
 

--- a/run_clm_annotated.py
+++ b/run_clm_annotated.py
@@ -772,3 +772,110 @@ def _mp_fn(index):
 
 if __name__ == "__main__":
     main()
+
+
+# =============================================================================
+# 4.5 代码阅读问题回答
+# =============================================================================
+
+# Q1: ModelArguments / DataTrainingArguments 一共有哪些可调参数？
+#
+# ModelArguments 主要参数：
+#   --model_name_or_path   从哪个 HF Hub 模型或本地路径加载模型
+#   --model_type           如果从零训练，指定模型类型（如 gpt2）
+#   --config_name          单独指定 config（不指定则和 model 一致）
+#   --tokenizer_name       单独指定 tokenizer
+#   --cache_dir            模型权重下载缓存目录
+#   --use_fast_tokenizer   是否使用 fast tokenizer（默认 True）
+#   --model_revision       加载哪个版本的模型
+#   --token                HF Hub 访问 token
+#   --trust_remote_code    是否信任远程自定义代码
+#   --torch_dtype          模型权重精度（auto/float32/float16/bfloat16）
+#   --low_cpu_mem_usage    低内存加载大模型
+#
+# DataTrainingArguments 主要参数：
+#   --dataset_name         HF Hub 数据集名称（如 wikitext）
+#   --dataset_config_name  数据集子集（如 wikitext-2-raw-v1）
+#   --train_file           本地训练文件路径（csv/json/txt）
+#   --validation_file      本地验证文件路径
+#   --block_size           每个训练样本的 token 长度
+#   --max_train_samples    限制训练样本数（调试用）
+#   --max_eval_samples     限制验证样本数
+#   --streaming            是否流式加载数据集（大数据集用）
+#   --validation_split_percentage  没有 val split 时从 train 切多少出来
+#   --preprocessing_num_workers   数据预处理并行进程数
+#   --keep_linebreaks      tokenize 时是否保留换行符
+
+
+# Q2: load_dataset 数据是怎么加载和切分的？
+#
+# 加载：
+#   如果有 --dataset_name，调用 load_dataset(dataset_name, dataset_config_name) 从 HF Hub 下载；
+#   如果没有 --dataset_name，根据 --train_file / --validation_file 扩展名判断格式（csv/json/txt），
+#   用 load_dataset("csv"/"json"/"text", data_files=...) 从本地加载。
+#
+# 切分：
+#   如果数据集本身有 validation split，直接使用；
+#   如果没有 validation split，使用 validation_split_percentage（默认 5%）
+#   从 train 中切出一部分：
+#     train[:5%] -> validation
+#     train[5%:] -> train
+#   streaming=True 时不支持直接切片，使用 split_streaming_dataset() 按序号近似切分。
+
+
+# Q3: 文本怎么变成 token block 的？
+#
+# 分两步：
+#
+# Step 1 - tokenize_function：
+#   读取 text_column_name 对应的原始文本列，
+#   调用 tokenizer() 把字符串转成 input_ids（token id 序列）。
+#   这一步每条样本长度不固定，还不能直接训练。
+#
+# Step 2 - group_texts：
+#   1. 把 batch 内所有样本的 token ids 用 chain() 串接成一条长 token 流；
+#   2. total_length = (total_length // block_size) * block_size，丢掉尾部不足一个 block 的 token；
+#   3. 每隔 block_size 切一次，得到多个等长 input_ids block；
+#   4. result["labels"] = result["input_ids"].copy()。
+#
+# 为什么 labels = input_ids.copy()？
+#   causal LM 的训练目标是预测下一个 token，labels 和 input_ids 是同一序列；
+#   模型内部会自动 shift（labels 向左移一位），所以这里直接复制就行。
+
+
+# Q4: Trainer 实例化接收哪些核心参数？
+#
+# trainer = Trainer(
+#     model=model,                        # 要训练的语言模型（AutoModelForCausalLM）
+#     args=training_args,                 # TrainingArguments：lr、batch_size、epochs、fp16、save 等
+#     train_dataset=train_dataset,        # 经过 tokenize+group_texts 的等长 token blocks
+#     eval_dataset=eval_dataset,          # 同上，用于评估
+#     processing_class=tokenizer,         # 保存模型时一起保存 tokenizer
+#     data_collator=default_data_collator,# 样本已等长，不需要 padding，直接合成 batch
+#     compute_metrics=compute_metrics,    # eval 时计算 accuracy
+#     preprocess_logits_for_metrics=...   # eval 时把 logits 转成预测 token ids
+# )
+
+
+# Q5: 训练循环 pseudo code
+#
+# trainer.train() 内部大致逻辑：
+#
+# model.train()
+# for epoch in range(num_train_epochs):
+#     for batch in train_dataloader:
+#         batch = batch.to(device)
+#         with autocast():                          # 混合精度
+#             outputs = model(**batch)
+#             loss = outputs.loss / gradient_accumulation_steps
+#         loss.backward()
+#         if step % gradient_accumulation_steps == 0:
+#             clip_grad_norm_(model.parameters())
+#             optimizer.step()
+#             lr_scheduler.step()
+#             optimizer.zero_grad()
+#         if step % logging_steps == 0:
+#             log(loss, lr, ...)
+#         if step % save_steps == 0:
+#             save_checkpoint()
+# save_model()

--- a/run_clm_annotated.py
+++ b/run_clm_annotated.py
@@ -78,10 +78,19 @@ MODEL_CONFIG_CLASSES = list(MODEL_FOR_CAUSAL_LM_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
 
 
-### ModelArguments / DataTrainingArguments ###
-# 模型参数：model_name_or_path, tokenizer, cache_dir 等
-# 数据参数：dataset_name, block_size, max_train_samples 等
-# 训练参数：继承自 TrainingArguments，包含 lr, batch_size, epochs 等
+### ModelArguments / DataTrainingArguments：定义命令行参数 ###
+# ModelArguments 控制模型相关设置：
+#   例如从哪个 checkpoint 加载模型、config、tokenizer；
+#   是否从零训练模型；
+#   cache_dir、model_revision、token、trust_remote_code、dtype 等。
+#
+# DataTrainingArguments 控制数据相关设置：
+#   例如从 Hugging Face Hub 加载 dataset_name，或从本地 train_file / validation_file 加载；
+#   设置 block_size、streaming、validation_split_percentage、max_train_samples、
+#   max_eval_samples、preprocessing_num_workers、keep_linebreaks 等。
+#
+# TrainingArguments 由 Transformers 库提供，不在本文件中定义；
+# 它控制训练超参数，例如 output_dir、learning_rate、batch_size、epochs、fp16、logging、save 等。
 @dataclass
 class ModelArguments:
     """
@@ -328,9 +337,17 @@ def main():
     #
     # For CSV/JSON files, this script will use the column called 'text' or the first column if no column called
     # 'text' is found. You can easily tweak this behavior (see below).
-### load_dataset ###
-# 从 HuggingFace datasets 加载数据集，自动下载并缓存
-# 支持按 split 切分：train/validation/test
+### load_dataset：加载数据集并构造 train / validation split ###
+# 如果提供 --dataset_name，则从 Hugging Face Hub 加载公开数据集；
+# 如果没有 --dataset_name，则根据 --train_file / --validation_file 从本地 csv/json/txt 文件加载。
+#
+# 如果原始数据没有 validation split，脚本会使用 validation_split_percentage
+# 从 train 中切出一部分作为 validation：
+#   train[:5%]  -> validation
+#   train[5%:]  -> train
+#
+# 如果 streaming=True，数据不能像普通 Dataset 那样直接切片，
+# 因此脚本使用 split_streaming_dataset() 按样本序号近似划分 train / validation。
     #
     # In distributed training, the load_dataset function guarantee that only one local process can concurrently
     # download the dataset.
@@ -505,9 +522,12 @@ def main():
 
     # since this will be pickled to avoid _LazyModule error in Hasher force logger loading before tokenize_function
     tok_logger = transformers.utils.logging.get_logger("transformers.tokenization_utils_base")
-### tokenize_function + group_texts ###
-# tokenize_function: 把文本转成 token id
-# group_texts: 把所有 token 拼接后按 block_size 切成等长块，用于语言模型训练
+### tokenize_function：把原始文本转成 token ids ###
+# 这里选择数据集中的文本列 text_column_name。
+# 如果数据集中有名为 "text" 的列，就使用 "text"；否则默认使用第一列。
+#
+# tokenizer(examples[text_column_name]) 把原始字符串转换成 input_ids。
+# 这一步只是 tokenize，还没有把 token 切成固定长度 block。
 
     def tokenize_function(examples):
         with CaptureLogger(tok_logger) as cl:
@@ -561,6 +581,18 @@ def main():
             )
         block_size = min(data_args.block_size, tokenizer.model_max_length)
 
+    ### group_texts：把 token 串接后切成固定长度 causal LM blocks ###
+    # causal language modeling 不是简单地把每一行文本当成一个训练样本。
+    # 这里先把 batch 内所有 token ids 串接成一条长 token 流，再按 block_size 切块。
+    #
+    # 具体步骤：
+    #   1. chain(*examples[k]) 把 token 列表拼接起来；
+    #   2. total_length = (total_length // block_size) * block_size，丢掉不整除的尾部；
+    #   3. 每隔 block_size 切一次，得到固定长度 input_ids blocks；
+    #   4. result["labels"] = result["input_ids"].copy()。
+    #
+    # 对 causal LM 来说，labels 和 input_ids 相同；
+    # 模型内部会自动 shift，训练目标是用前面的 token 预测下一个 token。
     # Main data processing function that will concatenate all texts from our dataset and generate chunks of block_size.
     def group_texts(examples):
         # Concatenate all texts.
@@ -638,9 +670,14 @@ def main():
             preds = preds[:, :-1].reshape(-1)
             return metric.compute(predictions=preds, references=labels)
 
-### Trainer 实例化 ###
-# Trainer 封装了训练循环，接收 model/args/datasets/tokenizer/data_collator
-# 自动处理：梯度累积、混合精度、分布式训练、checkpoint 保存
+### Trainer 实例化：把模型、数据、训练参数交给 Trainer ###
+# Trainer 封装了 PyTorch 训练循环，核心参数包括：
+#   model: 要训练的 AutoModelForCausalLM；
+#   args: TrainingArguments，包含 lr、batch_size、epochs、保存、日志、混合精度等；
+#   train_dataset / eval_dataset: tokenize + group_texts 后得到的固定长度 LM blocks；
+#   processing_class=tokenizer: 保存模型时一起保存 tokenizer；
+#   data_collator=default_data_collator: 因为样本已等长，不需要 padding，直接合成 batch；
+#   compute_metrics / preprocess_logits_for_metrics: eval 时把 logits 转成预测 token 并计算 accuracy。
     # Initialize our Trainer
     trainer = Trainer(
         model=model,
@@ -657,12 +694,23 @@ def main():
     )
 
     # Training
+    ### trainer.train()：启动训练循环 ###
+    # 当 training_args.do_train=True 时，这一块会真正开始训练。
+    # 如果设置了 resume_from_checkpoint，就从已有 checkpoint 继续训练；否则从当前模型参数开始。
+    #
+    # trainer.train() 内部大致执行：
+    #   for epoch in num_train_epochs:
+    #       for batch in train_dataloader:
+    #           outputs = model(**batch)
+    #           loss = outputs.loss
+    #           loss.backward()
+    #           optimizer.step(); lr_scheduler.step(); optimizer.zero_grad()
+    #
+    # Trainer 自动处理梯度累积、混合精度、分布式训练、日志和 checkpoint 保存。
+    # 训练结束后调用 save_model()、log_metrics()、save_metrics()、save_state() 保存结果。
     if training_args.do_train:
         checkpoint = None
         if training_args.resume_from_checkpoint is not None:
-### trainer.train() ###
-# 启动训练循环，支持从 checkpoint 恢复
-# 内部逻辑：for epoch: for batch: forward -> loss -> backward -> step
             checkpoint = training_args.resume_from_checkpoint
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         trainer.save_model()  # Saves the tokenizer too for easy upload

--- a/run_clm_annotated.py
+++ b/run_clm_annotated.py
@@ -1,0 +1,726 @@
+#!/usr/bin/env python
+# Copyright 2020 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# /// script
+# dependencies = [
+#     "transformers @ git+https://github.com/huggingface/transformers.git",
+#     "albumentations >= 1.4.16",
+#     "accelerate >= 0.12.0",
+#     "torch >= 1.3",
+#     "datasets >= 2.14.0",
+#     "sentencepiece != 0.1.92",
+#     "protobuf",
+#     "evaluate",
+#     "scikit-learn",
+# ]
+# ///
+
+"""
+Fine-tuning the library models for causal language modeling (GPT, GPT-2, CTRL, ...) on a text file or a dataset.
+
+Here is the full list of checkpoints on the hub that can be fine-tuned by this script:
+https://huggingface.co/models?filter=text-generation
+"""
+# You can also adapt this script on your own causal language modeling task. Pointers for this are left as comments.
+
+import logging
+import math
+import os
+import sys
+from dataclasses import dataclass, field
+from itertools import chain
+
+import datasets
+import evaluate
+import torch
+from datasets import IterableDataset, IterableDatasetDict, load_dataset
+
+import transformers
+from transformers import (
+    CONFIG_MAPPING,
+    MODEL_FOR_CAUSAL_LM_MAPPING,
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    HfArgumentParser,
+    Trainer,
+    TrainingArguments,
+    default_data_collator,
+    is_torch_xla_available,
+    set_seed,
+)
+from transformers.testing_utils import CaptureLogger
+from transformers.utils import check_min_version
+from transformers.utils.versions import require_version
+
+
+# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
+check_min_version("4.57.0.dev0")
+
+require_version("datasets>=2.14.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+
+logger = logging.getLogger(__name__)
+
+
+MODEL_CONFIG_CLASSES = list(MODEL_FOR_CAUSAL_LM_MAPPING.keys())
+MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
+
+
+### ModelArguments / DataTrainingArguments ###
+# 模型参数：model_name_or_path, tokenizer, cache_dir 等
+# 数据参数：dataset_name, block_size, max_train_samples 等
+# 训练参数：继承自 TrainingArguments，包含 lr, batch_size, epochs 等
+@dataclass
+class ModelArguments:
+    """
+    Arguments pertaining to which model/config/tokenizer we are going to fine-tune, or train from scratch.
+    """
+
+    model_name_or_path: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "The model checkpoint for weights initialization. Don't set if you want to train a model from scratch."
+            )
+        },
+    )
+    model_type: str | None = field(
+        default=None,
+        metadata={"help": "If training from scratch, pass a model type from the list: " + ", ".join(MODEL_TYPES)},
+    )
+    config_overrides: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Override some existing default config settings when a model is trained from scratch. Example: "
+                "n_embd=10,resid_pdrop=0.2,scale_attn_weights=false,summary_type=cls_index"
+            )
+        },
+    )
+    config_name: str | None = field(
+        default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
+    )
+    tokenizer_name: str | None = field(
+        default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"}
+    )
+    cache_dir: str | None = field(
+        default=None,
+        metadata={"help": "Where do you want to store the pretrained models downloaded from huggingface.co"},
+    )
+    use_fast_tokenizer: bool = field(
+        default=True,
+        metadata={"help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."},
+    )
+    model_revision: str = field(
+        default="main",
+        metadata={"help": "The specific model version to use (can be a branch name, tag name or commit id)."},
+    )
+    token: str = field(
+        default=None,
+        metadata={
+            "help": (
+                "The token to use as HTTP bearer authorization for remote files. If not specified, will use the token "
+                "generated when running `hf auth login` (stored in `~/.huggingface`)."
+            )
+        },
+    )
+    trust_remote_code: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to trust the execution of code from datasets/models defined on the Hub."
+                " This option should only be set to `True` for repositories you trust and in which you have read the"
+                " code, as it will execute code present on the Hub on your local machine."
+            )
+        },
+    )
+    dtype: str | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Override the default `torch.dtype` and load the model under this dtype. If `auto` is passed, the "
+                "dtype will be automatically derived from the model's weights."
+            ),
+            "choices": ["auto", "bfloat16", "float16", "float32"],
+        },
+    )
+
+    def __post_init__(self):
+        if self.config_overrides is not None and (self.config_name is not None or self.model_name_or_path is not None):
+            raise ValueError(
+                "--config_overrides can't be used in combination with --config_name or --model_name_or_path"
+            )
+
+
+@dataclass
+class DataTrainingArguments:
+    """
+    Arguments pertaining to what data we are going to input our model for training and eval.
+    """
+
+    dataset_name: str | None = field(
+        default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
+    )
+    dataset_config_name: str | None = field(
+        default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
+    )
+    train_file: str | None = field(default=None, metadata={"help": "The input training data file (a text file)."})
+    validation_file: str | None = field(
+        default=None,
+        metadata={"help": "An optional input evaluation data file to evaluate the perplexity on (a text file)."},
+    )
+    max_train_samples: int | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of training examples to this "
+                "value if set."
+            )
+        },
+    )
+    max_eval_samples: int | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "For debugging purposes or quicker training, truncate the number of evaluation examples to this "
+                "value if set."
+            )
+        },
+    )
+    streaming: bool = field(default=False, metadata={"help": "Enable streaming mode"})
+    block_size: int | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Optional input sequence length after tokenization. "
+                "The training dataset will be truncated in block of this size for training. "
+                "Default to the model max input length for single sentence inputs (take into account special tokens)."
+            )
+        },
+    )
+    overwrite_cache: bool = field(
+        default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
+    )
+    validation_split_percentage: int | None = field(
+        default=5,
+        metadata={
+            "help": "The percentage of the train set used as validation set in case there's no validation split"
+        },
+    )
+    preprocessing_num_workers: int | None = field(
+        default=None,
+        metadata={"help": "The number of processes to use for the preprocessing."},
+    )
+    keep_linebreaks: bool = field(
+        default=True, metadata={"help": "Whether to keep line breaks when using TXT files or not."}
+    )
+
+    def __post_init__(self):
+        if self.streaming:
+            require_version("datasets>=2.0.0", "The streaming feature requires `datasets>=2.0.0`")
+
+        if self.dataset_name is None and self.train_file is None and self.validation_file is None:
+            raise ValueError("Need either a dataset name or a training/validation file.")
+        else:
+            if self.train_file is not None:
+                extension = self.train_file.split(".")[-1]
+                assert extension in ["csv", "json", "txt"], "`train_file` should be a csv, a json or a txt file."
+            if self.validation_file is not None:
+                extension = self.validation_file.split(".")[-1]
+                assert extension in ["csv", "json", "txt"], "`validation_file` should be a csv, a json or a txt file."
+
+
+def split_streaming_dataset(
+    full_streaming_dataset,
+    validation_percentage: int = 5,
+) -> IterableDatasetDict:
+    """
+    Splits a streaming dataset into
+    training and validation IterableDatasets, and supports methods like .map(), .filter(),
+    .take() and properties like .features on the resulting streams.
+
+    Args:
+        full_streaming_dataset (Dataset): The name of the dataset to load (e.g., "HuggingFaceFW/fineweb").
+        validation_percentage (int): The proportion of the dataset to be used for validation split.
+
+    Returns:
+        IterableDatasetDict: An IterableDatasetDict containing two IterableDataset objects: (train_stream, validation_stream).
+    """
+    if not (0 < validation_percentage < 100):
+        raise ValueError(
+            f"validation_percentage must be between 0 and 100 (exclusive). Passed: {validation_percentage}"
+        )
+
+    def split_generator(is_train: bool):
+        for i, example in enumerate(full_streaming_dataset):
+            if is_train:
+                if i % 100 > validation_percentage:
+                    yield example
+            else:
+                if i % 100 < validation_percentage:
+                    yield example
+
+    features = full_streaming_dataset.features
+    train_stream = IterableDataset.from_generator(split_generator, gen_kwargs={"is_train": True}, features=features)
+    validation_stream = IterableDataset.from_generator(
+        split_generator, gen_kwargs={"is_train": False}, features=features
+    )
+
+    return IterableDatasetDict({"train": train_stream, "validation": validation_stream})
+
+
+def main():
+    # See all possible arguments in src/transformers/training_args.py
+    # or by passing the --help flag to this script.
+    # We now keep distinct sets of args, for a cleaner separation of concerns.
+
+    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments))
+    if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
+        # If we pass only one argument to the script and it's the path to a json file,
+        # let's parse it to get our arguments.
+        model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
+    else:
+        model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+
+    # Setup logging
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+    if training_args.should_log:
+        # The default of training_args.log_level is passive, so we set log level at info here to have that default.
+        transformers.utils.logging.set_verbosity_info()
+
+    log_level = training_args.get_process_log_level()
+    logger.setLevel(log_level)
+    datasets.utils.logging.set_verbosity(log_level)
+    transformers.utils.logging.set_verbosity(log_level)
+    transformers.utils.logging.enable_default_handler()
+    transformers.utils.logging.enable_explicit_format()
+
+    # Log on each process the small summary:
+    logger.warning(
+        f"Process rank: {training_args.local_process_index}, device: {training_args.device}, n_gpu: {training_args.n_gpu}, "
+        + f"distributed training: {training_args.parallel_mode.value == 'distributed'}, 16-bits training: {training_args.fp16}"
+    )
+    logger.info(f"Training/evaluation parameters {training_args}")
+
+    # Set seed before initializing model.
+    set_seed(training_args.seed)
+
+    # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
+    # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
+    # (the dataset will be downloaded automatically from the datasets Hub).
+    #
+    # For CSV/JSON files, this script will use the column called 'text' or the first column if no column called
+    # 'text' is found. You can easily tweak this behavior (see below).
+### load_dataset ###
+# 从 HuggingFace datasets 加载数据集，自动下载并缓存
+# 支持按 split 切分：train/validation/test
+    #
+    # In distributed training, the load_dataset function guarantee that only one local process can concurrently
+    # download the dataset.
+    if data_args.dataset_name is not None:
+        # Downloading and loading a dataset from the hub.
+        raw_datasets = load_dataset(
+            data_args.dataset_name,
+            data_args.dataset_config_name,
+            cache_dir=model_args.cache_dir,
+            token=model_args.token,
+            streaming=data_args.streaming,
+            trust_remote_code=model_args.trust_remote_code,
+        )
+        if "validation" not in raw_datasets:
+            if data_args.streaming:
+                dataset_stream = load_dataset(
+                    data_args.dataset_name,
+                    data_args.dataset_config_name,
+                    split="train",
+                    cache_dir=model_args.cache_dir,
+                    token=model_args.token,
+                    streaming=data_args.streaming,
+                    trust_remote_code=model_args.trust_remote_code,
+                )
+                raw_datasets = split_streaming_dataset(dataset_stream, data_args.validation_split_percentage)
+            else:
+                raw_datasets["validation"] = load_dataset(
+                    data_args.dataset_name,
+                    data_args.dataset_config_name,
+                    split=f"train[:{data_args.validation_split_percentage}%]",
+                    cache_dir=model_args.cache_dir,
+                    token=model_args.token,
+                    streaming=data_args.streaming,
+                    trust_remote_code=model_args.trust_remote_code,
+                )
+                raw_datasets["train"] = load_dataset(
+                    data_args.dataset_name,
+                    data_args.dataset_config_name,
+                    split=f"train[{data_args.validation_split_percentage}%:]",
+                    cache_dir=model_args.cache_dir,
+                    token=model_args.token,
+                    streaming=data_args.streaming,
+                    trust_remote_code=model_args.trust_remote_code,
+                )
+    else:
+        data_files = {}
+        dataset_args = {}
+        if data_args.train_file is not None:
+            data_files["train"] = data_args.train_file
+        if data_args.validation_file is not None:
+            data_files["validation"] = data_args.validation_file
+        extension = (
+            data_args.train_file.split(".")[-1]
+            if data_args.train_file is not None
+            else data_args.validation_file.split(".")[-1]
+        )
+        if extension == "txt":
+            extension = "text"
+            dataset_args["keep_linebreaks"] = data_args.keep_linebreaks
+        raw_datasets = load_dataset(
+            extension,
+            data_files=data_files,
+            cache_dir=model_args.cache_dir,
+            token=model_args.token,
+            **dataset_args,
+        )
+        # If no validation data is there, validation_split_percentage will be used to divide the dataset.
+        if "validation" not in raw_datasets:
+            if data_args.streaming:
+                dataset_stream = load_dataset(
+                    extension,
+                    data_files=data_files,
+                    split="train",
+                    cache_dir=model_args.cache_dir,
+                    token=model_args.token,
+                    **dataset_args,
+                )
+                raw_datasets = split_streaming_dataset(dataset_stream, data_args.validation_split_percentage)
+            else:
+                raw_datasets["validation"] = load_dataset(
+                    extension,
+                    data_files=data_files,
+                    split=f"train[:{data_args.validation_split_percentage}%]",
+                    cache_dir=model_args.cache_dir,
+                    token=model_args.token,
+                    **dataset_args,
+                )
+
+                raw_datasets["train"] = load_dataset(
+                    extension,
+                    data_files=data_files,
+                    split=f"train[{data_args.validation_split_percentage}%:]",
+                    cache_dir=model_args.cache_dir,
+                    token=model_args.token,
+                    **dataset_args,
+                )
+
+    # See more about loading any type of standard or custom dataset (from files, python dict, pandas DataFrame, etc) at
+    # https://huggingface.co/docs/datasets/loading_datasets.
+
+    # Load pretrained model and tokenizer
+    #
+    # Distributed training:
+    # The .from_pretrained methods guarantee that only one local process can concurrently
+    # download model & vocab.
+
+    config_kwargs = {
+        "cache_dir": model_args.cache_dir,
+        "revision": model_args.model_revision,
+        "token": model_args.token,
+        "trust_remote_code": model_args.trust_remote_code,
+    }
+    if model_args.config_name:
+        config = AutoConfig.from_pretrained(model_args.config_name, **config_kwargs)
+    elif model_args.model_name_or_path:
+        config = AutoConfig.from_pretrained(model_args.model_name_or_path, **config_kwargs)
+    else:
+        config = CONFIG_MAPPING[model_args.model_type]()
+        logger.warning("You are instantiating a new config instance from scratch.")
+        if model_args.config_overrides is not None:
+            logger.info(f"Overriding config: {model_args.config_overrides}")
+            config.update_from_string(model_args.config_overrides)
+            logger.info(f"New config: {config}")
+
+    tokenizer_kwargs = {
+        "cache_dir": model_args.cache_dir,
+        "use_fast": model_args.use_fast_tokenizer,
+        "revision": model_args.model_revision,
+        "token": model_args.token,
+        "trust_remote_code": model_args.trust_remote_code,
+    }
+    if model_args.tokenizer_name:
+        tokenizer = AutoTokenizer.from_pretrained(model_args.tokenizer_name, **tokenizer_kwargs)
+    elif model_args.model_name_or_path:
+        tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path, **tokenizer_kwargs)
+    else:
+        raise ValueError(
+            "You are instantiating a new tokenizer from scratch. This is not supported by this script. "
+            "You can do it from another script, save it, and load it from here, using --tokenizer_name."
+        )
+
+    if model_args.model_name_or_path:
+        dtype = model_args.dtype if model_args.dtype in ["auto", None] else getattr(torch, model_args.dtype)
+        model = AutoModelForCausalLM.from_pretrained(
+            model_args.model_name_or_path,
+            from_tf=bool(".ckpt" in model_args.model_name_or_path),
+            config=config,
+            cache_dir=model_args.cache_dir,
+            revision=model_args.model_revision,
+            token=model_args.token,
+            trust_remote_code=model_args.trust_remote_code,
+            dtype=dtype,
+        )
+    else:
+        model = AutoModelForCausalLM.from_config(config, trust_remote_code=model_args.trust_remote_code)
+        n_params = sum({p.data_ptr(): p.numel() for p in model.parameters()}.values())
+        logger.info(f"Training new model from scratch - Total size={n_params / 2**20:.2f}M params")
+
+    # We resize the embeddings only when necessary to avoid index errors. If you are creating a model from scratch
+    # on a small vocab and want a smaller embedding size, remove this test.
+    embedding_size = model.get_input_embeddings().weight.shape[0]
+    if len(tokenizer) > embedding_size:
+        model.resize_token_embeddings(len(tokenizer))
+
+    # Preprocessing the datasets.
+    # First we tokenize all the texts.
+    if training_args.do_train:
+        column_names = list(raw_datasets["train"].features)
+    else:
+        column_names = list(raw_datasets["validation"].features)
+    text_column_name = "text" if "text" in column_names else column_names[0]
+
+    # since this will be pickled to avoid _LazyModule error in Hasher force logger loading before tokenize_function
+    tok_logger = transformers.utils.logging.get_logger("transformers.tokenization_utils_base")
+### tokenize_function + group_texts ###
+# tokenize_function: 把文本转成 token id
+# group_texts: 把所有 token 拼接后按 block_size 切成等长块，用于语言模型训练
+
+    def tokenize_function(examples):
+        with CaptureLogger(tok_logger) as cl:
+            output = tokenizer(examples[text_column_name])
+        # clm input could be much much longer than block_size
+        if "Token indices sequence length is longer than the" in cl.out:
+            tok_logger.warning(
+                "^^^^^^^^^^^^^^^^ Please ignore the warning above - this long input will be chunked into smaller bits"
+                " before being passed to the model."
+            )
+        return output
+
+    with training_args.main_process_first(desc="dataset map tokenization"):
+        if not data_args.streaming:
+            tokenized_datasets = raw_datasets.map(
+                tokenize_function,
+                batched=True,
+                num_proc=data_args.preprocessing_num_workers,
+                remove_columns=column_names,
+                load_from_cache_file=not data_args.overwrite_cache,
+                desc="Running tokenizer on dataset",
+            )
+        else:
+            tokenized_datasets = raw_datasets.map(
+                tokenize_function,
+                batched=True,
+                remove_columns=column_names,
+            )
+    if hasattr(config, "max_position_embeddings"):
+        max_pos_embeddings = config.max_position_embeddings
+    else:
+        # Define a default value if the attribute is missing in the config.
+        max_pos_embeddings = 1024
+
+    if data_args.block_size is None:
+        block_size = tokenizer.model_max_length
+        if block_size > max_pos_embeddings:
+            logger.warning(
+                f"The tokenizer picked seems to have a very large `model_max_length` ({tokenizer.model_max_length}). "
+                f"Using block_size={min(1024, max_pos_embeddings)} instead. You can change that default value by passing --block_size xxx."
+            )
+            if max_pos_embeddings > 0:
+                block_size = min(1024, max_pos_embeddings)
+            else:
+                block_size = 1024
+    else:
+        if data_args.block_size > tokenizer.model_max_length:
+            logger.warning(
+                f"The block_size passed ({data_args.block_size}) is larger than the maximum length for the model "
+                f"({tokenizer.model_max_length}). Using block_size={tokenizer.model_max_length}."
+            )
+        block_size = min(data_args.block_size, tokenizer.model_max_length)
+
+    # Main data processing function that will concatenate all texts from our dataset and generate chunks of block_size.
+    def group_texts(examples):
+        # Concatenate all texts.
+        concatenated_examples = {k: list(chain(*examples[k])) for k in examples}
+        total_length = len(concatenated_examples[list(examples.keys())[0]])
+        # We drop the small remainder, and if the total_length < block_size  we exclude this batch and return an empty dict.
+        # We could add padding if the model supported it instead of this drop, you can customize this part to your needs.
+        total_length = (total_length // block_size) * block_size
+        # Split by chunks of max_len.
+        result = {
+            k: [t[i : i + block_size] for i in range(0, total_length, block_size)]
+            for k, t in concatenated_examples.items()
+        }
+        result["labels"] = result["input_ids"].copy()
+        return result
+
+    # Note that with `batched=True`, this map processes 1,000 texts together, so group_texts throws away a remainder
+    # for each of those groups of 1,000 texts. You can adjust that batch_size here but a higher value might be slower
+    # to preprocess.
+    #
+    # To speed up this part, we use multiprocessing. See the documentation of the map method for more information:
+    # https://huggingface.co/docs/datasets/process#map
+
+    with training_args.main_process_first(desc="grouping texts together"):
+        if not data_args.streaming:
+            lm_datasets = tokenized_datasets.map(
+                group_texts,
+                batched=True,
+                num_proc=data_args.preprocessing_num_workers,
+                load_from_cache_file=not data_args.overwrite_cache,
+                desc=f"Grouping texts in chunks of {block_size}",
+            )
+        else:
+            lm_datasets = tokenized_datasets.map(
+                group_texts,
+                batched=True,
+            )
+
+    if training_args.do_train:
+        if "train" not in tokenized_datasets:
+            raise ValueError("--do_train requires a train dataset")
+        train_dataset = lm_datasets["train"]
+        if data_args.max_train_samples is not None:
+            if data_args.streaming:
+                train_dataset = train_dataset.take(data_args.max_train_samples)
+            else:
+                max_train_samples = min(len(train_dataset), data_args.max_train_samples)
+                train_dataset = train_dataset.select(range(max_train_samples))
+
+    if training_args.do_eval:
+        if "validation" not in tokenized_datasets:
+            raise ValueError("--do_eval requires a validation dataset")
+        eval_dataset = lm_datasets["validation"]
+        if data_args.max_eval_samples is not None:
+            if data_args.streaming:
+                eval_dataset = eval_dataset.take(data_args.max_eval_samples)
+            else:
+                max_eval_samples = min(len(eval_dataset), data_args.max_eval_samples)
+                eval_dataset = eval_dataset.select(range(max_eval_samples))
+
+        def preprocess_logits_for_metrics(logits, labels):
+            if isinstance(logits, tuple):
+                # Depending on the model and config, logits may contain extra tensors,
+                # like past_key_values, but logits always come first
+                logits = logits[0]
+            return logits.argmax(dim=-1)
+
+        metric = evaluate.load("accuracy", cache_dir=model_args.cache_dir)
+
+        def compute_metrics(eval_preds):
+            preds, labels = eval_preds
+            # preds have the same shape as the labels, after the argmax(-1) has been calculated
+            # by preprocess_logits_for_metrics but we need to shift the labels
+            labels = labels[:, 1:].reshape(-1)
+            preds = preds[:, :-1].reshape(-1)
+            return metric.compute(predictions=preds, references=labels)
+
+### Trainer 实例化 ###
+# Trainer 封装了训练循环，接收 model/args/datasets/tokenizer/data_collator
+# 自动处理：梯度累积、混合精度、分布式训练、checkpoint 保存
+    # Initialize our Trainer
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset if training_args.do_train else None,
+        eval_dataset=eval_dataset if training_args.do_eval else None,
+        processing_class=tokenizer,
+        # Data collator will default to DataCollatorWithPadding, so we change it.
+        data_collator=default_data_collator,
+        compute_metrics=compute_metrics if training_args.do_eval and not is_torch_xla_available() else None,
+        preprocess_logits_for_metrics=preprocess_logits_for_metrics
+        if training_args.do_eval and not is_torch_xla_available()
+        else None,
+    )
+
+    # Training
+    if training_args.do_train:
+        checkpoint = None
+        if training_args.resume_from_checkpoint is not None:
+### trainer.train() ###
+# 启动训练循环，支持从 checkpoint 恢复
+# 内部逻辑：for epoch: for batch: forward -> loss -> backward -> step
+            checkpoint = training_args.resume_from_checkpoint
+        train_result = trainer.train(resume_from_checkpoint=checkpoint)
+        trainer.save_model()  # Saves the tokenizer too for easy upload
+
+        metrics = train_result.metrics
+
+        max_train_samples = (
+            data_args.max_train_samples if data_args.max_train_samples is not None else len(train_dataset)
+        )
+        if data_args.streaming:
+            metrics["train_samples"] = max_train_samples
+        else:
+            metrics["train_samples"] = min(max_train_samples, len(train_dataset))
+
+        trainer.log_metrics("train", metrics)
+        trainer.save_metrics("train", metrics)
+        trainer.save_state()
+
+    # Evaluation
+    if training_args.do_eval:
+        logger.info("*** Evaluate ***")
+
+        metrics = trainer.evaluate()
+
+        max_eval_samples = data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
+        if data_args.streaming:
+            metrics["eval_samples"] = max_eval_samples
+        else:
+            metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
+
+        try:
+            perplexity = math.exp(metrics["eval_loss"])
+        except OverflowError:
+            perplexity = float("inf")
+        metrics["perplexity"] = perplexity
+
+        trainer.log_metrics("eval", metrics)
+        trainer.save_metrics("eval", metrics)
+
+    kwargs = {"finetuned_from": model_args.model_name_or_path, "tasks": "text-generation"}
+    if data_args.dataset_name is not None:
+        kwargs["dataset_tags"] = data_args.dataset_name
+        if data_args.dataset_config_name is not None:
+            kwargs["dataset_args"] = data_args.dataset_config_name
+            kwargs["dataset"] = f"{data_args.dataset_name} {data_args.dataset_config_name}"
+        else:
+            kwargs["dataset"] = data_args.dataset_name
+
+    if training_args.push_to_hub:
+        trainer.push_to_hub(**kwargs)
+    else:
+        trainer.create_model_card(**kwargs)
+
+
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_week3_experiments.sh
+++ b/scripts/run_week3_experiments.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMON="wandb_log=true wandb_project=nanogpt wandb_group=week3-short seed=42 optim.max_iters=120 eval_interval=60 eval_iters=20 log_interval=20 checkpoint_interval=10000 compile=false"
+OUT=/root/autodl-tmp/ckpt/week3
+mkdir -p "$OUT" logs
+
+run() {
+  name="$1"
+  shift
+  echo "===== RUN $name ====="
+  python train.py $COMMON wandb_run_name="$name" out_dir="$OUT/$name" "$@" 2>&1 | tee "logs/${name}.log"
+}
+
+# Day 2: parameter-level changes
+run week3_day2_baseline
+run week3_day2_lr3e-4 optim.learning_rate=0.0003
+run week3_day2_lr1e-3 optim.learning_rate=0.001
+run week3_day2_bs32 data.batch_size=32
+run week3_day2_bs128 data.batch_size=128
+run week3_day2_dropout0.1 model.dropout=0.1
+run week3_day2_dropout0.2 model.dropout=0.2
+run week3_day2_sgd optim.name=sgd optim.learning_rate=0.01 optim.weight_decay=0.0 optim.decay_lr=false
+
+# Day 3: module-level changes
+run week3_day3_silu model.activation=silu
+run week3_day3_relu model.activation=relu
+run week3_day3_head2 model.n_head=2
+run week3_day3_head8 model.n_head=8
+run week3_day3_postln model.norm_position=post
+
+# Day 4: dense vs MoE changes
+run week3_day4_dense
+run week3_day4_moe_k2 model.use_moe=true model.moe_n_experts=4 model.moe_top_k=2 model.moe_aux_loss_weight=0.01
+run week3_day4_moe_k1 model.use_moe=true model.moe_n_experts=4 model.moe_top_k=1 model.moe_aux_loss_weight=0.01

--- a/train.py
+++ b/train.py
@@ -1,377 +1,239 @@
-"""                                                                                                                                                                                                           
-This training script can be run both on a single gpu in debug mode,                                                                                                                                         
-and also in a larger training run with distributed data parallel (ddp).
-                                                                                                                                                                                                              
-To run on a single GPU, example:
-$ python train.py --batch_size=32 --compile=False                                                                                                                                                             
-                                                                                                                                                                                                              
-To run with DDP on 4 gpus on 1 node, example:                                                                                                                                                                 
-$ torchrun --standalone --nproc_per_node=4 train.py                                                                                                                                                           
-                                                                                                                                                                                                              
-To run with DDP on 4 gpus across 2 nodes, example:                                                                                                                                                          
-- Run on the first (master) node with example IP 123.456.123.456:                                                                                                                                             
-$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 --master_addr=123.456.123.456 --master_port=1234 train.py                                                                                              
-- Run on the worker node:                                                                                                                                                                                     
-$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123.456 --master_port=1234 train.py                                                                                              
-(If your cluster does not have Infiniband interconnect prepend NCCL_IB_DISABLE=1)                                                                                                                             
-"""                                                                                                                                                                                                           
-                                                                                                                                                                                                              
-import os                                                                                                                                                                                                     
-import random                                                                                                                                                                                               
+import os
+import random
 import time
 import math
 import pickle
 from contextlib import nullcontext
-                                                                                                                                                                                                              
+
 import numpy as np
-import torch                                                                                                                                                                                                  
-from torch.nn.parallel import DistributedDataParallel as DDP                                                                                                                                                
+import torch
+from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.distributed import init_process_group, destroy_process_group
-                                                                                                                                                                                                              
-from model import GPTConfig, GPT                                                                                                                                                                              
-                                                                                                                                                                                                              
-# -----------------------------------------------------------------------------                                                                                                                               
-# default config values designed to train a gpt2 (124M) on OpenWebText                                                                                                                                      
-# I/O                                                                                                                                                                                                         
-out_dir = '/root/autodl-tmp/ckpt'                                                                                                                                                                             
-eval_interval = 2000                                                                                                                                                                                          
-log_interval = 1                                                                                                                                                                                              
-eval_iters = 200                                                                                                                                                                                            
-eval_only = False # if True, script exits right after the first eval
-always_save_checkpoint = True # if True, always save a checkpoint after each eval                                                                                                                             
-checkpoint_interval = 500  # save a periodic checkpoint every N iters
-seed = 1337  # random seed for reproducibility                                                                                                                                                                
-init_from = 'scratch' # 'scratch' or 'resume' or 'gpt2*'                                                                                                                                                      
-# wandb logging                                                                                                                                                                                               
-wandb_log = False # disabled by default                                                                                                                                                                       
-wandb_project = 'owt'                                                                                                                                                                                         
-wandb_run_name = 'gpt2' # 'run' + str(time.time())                                                                                                                                                          
-# data                                                                                                                                                                                                        
-dataset = 'openwebtext'                                                                                                                                                                                     
-gradient_accumulation_steps = 5 * 8 # used to simulate larger batch sizes                                                                                                                                     
-batch_size = 12 # if gradient_accumulation_steps > 1, this is the micro-batch size                                                                                                                            
-block_size = 1024                                                                                                                                                                                             
-# model                                                                                                                                                                                                       
-n_layer = 12                                                                                                                                                                                                  
-n_head = 12                                                                                                                                                                                                 
-n_embd = 768                                                                                                                                                                                                  
-dropout = 0.0 # for pretraining 0 is good, for finetuning try 0.1+                                                                                                                                          
-bias = False # do we use bias inside LayerNorm and Linear layers?                                                                                                                                             
-# adamw optimizer                                                                                                                                                                                             
-learning_rate = 6e-4 # max learning rate                                                                                                                                                                      
-max_iters = 600000 # total number of training iterations                                                                                                                                                      
-weight_decay = 1e-1                                                                                                                                                                                           
-beta1 = 0.9                                                                                                                                                                                                   
-beta2 = 0.95                                                                                                                                                                                                  
-grad_clip = 1.0 # clip gradients at this value, or disable if == 0.0                                                                                                                                        
-# learning rate decay settings                                                                                                                                                                                
-decay_lr = True # whether to decay the learning rate                                                                                                                                                          
-warmup_iters = 2000 # how many steps to warm up for                                                                                                                                                           
-lr_decay_iters = 600000 # should be ~= max_iters per Chinchilla                                                                                                                                               
-min_lr = 6e-5 # minimum learning rate, should be ~= learning_rate/10 per Chinchilla                                                                                                                           
-# DDP settings                                                                                                                                                                                                
-backend = 'nccl' # 'nccl', 'gloo', etc.                                                                                                                                                                       
-# system                                                                                                                                                                                                      
-device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks                                                                                                                
-dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler                          
-compile = True # use PyTorch 2.0 to compile the model to be faster                                                                                                                                            
-# -----------------------------------------------------------------------------                                                                                                                               
-config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]                                                                                            
-exec(open('configurator.py').read()) # overrides from command line or config file                                                                                                                             
-config = {k: globals()[k] for k in config_keys} # will be useful for logging                                                                                                                                  
-# -----------------------------------------------------------------------------                                                                                                                               
-                                                                                                                                                                                                              
-def set_seed(s):                                                                                                                                                                                              
-    random.seed(s)                                                                                                                                                                                          
-    np.random.seed(s)                                                                                                                                                                                         
-    torch.manual_seed(s)                                                                                                                                                                                    
+
+import hydra
+from omegaconf import DictConfig, OmegaConf
+
+from model import GPTConfig, GPT
+
+
+def set_seed(s):
+    random.seed(s)
+    np.random.seed(s)
+    torch.manual_seed(s)
     torch.cuda.manual_seed_all(s)
     torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False                                                                                                                                                                    
+    torch.backends.cudnn.benchmark = False
     os.environ["PYTHONHASHSEED"] = str(s)
-                                                                                                                                                                                                              
-# various inits, derived attributes, I/O setup                                                                                                                                                                
-ddp = int(os.environ.get('RANK', -1)) != -1 # is this a ddp run?
-if ddp:                                                                                                                                                                                                       
-    init_process_group(backend=backend)                                                                                                                                                                     
-    ddp_rank = int(os.environ['RANK'])                                                                                                                                                                        
-    ddp_local_rank = int(os.environ['LOCAL_RANK'])                                                                                                                                                            
-    ddp_world_size = int(os.environ['WORLD_SIZE'])
-    device = f'cuda:{ddp_local_rank}'                                                                                                                                                                         
-    torch.cuda.set_device(device)                                                                                                                                                                           
-    master_process = ddp_rank == 0 # this process will do logging, checkpointing etc.                                                                                                                         
-    seed_offset = ddp_rank # each process gets a different seed                                                                                                                                               
-    # world_size number of processes will be training simultaneously, so we can scale                                                                                                                         
-    # down the desired gradient accumulation iterations per process proportionally                                                                                                                            
-    assert gradient_accumulation_steps % ddp_world_size == 0                                                                                                                                                  
-    gradient_accumulation_steps //= ddp_world_size                                                                                                                                                            
-else:                                                                                                                                                                                                         
-    # if not ddp, we are running on a single gpu, and one process                                                                                                                                             
-    master_process = True                                                                                                                                                                                     
-    seed_offset = 0
-    ddp_world_size = 1                                                                                                                                                                                        
-tokens_per_iter = gradient_accumulation_steps * ddp_world_size * batch_size * block_size                                                                                                                      
-print(f"tokens per iteration will be: {tokens_per_iter:,}")
-                                                                                                                                                                                                              
-if master_process:                                                                                                                                                                                          
-    os.makedirs(out_dir, exist_ok=True)                                                                                                                                                                       
-set_seed(seed + seed_offset)                                                                                                                                                                                  
-torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
-torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn                                                                                                                                                  
-device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast                                                                                                                       
-# note: float16 data type will automatically use a GradScaler                                                                                                                                                 
-ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]                                                                                                             
-ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)                                                                                                   
-                                                                                                                                                                                                              
-# poor man's data loader                                                                                                                                                                                      
-data_dir = os.path.join('data', dataset)                                                                                                                                                                      
-def get_batch(split):                                                                                                                                                                                         
-    # We recreate np.memmap every batch to avoid a memory leak, as per                                                                                                                                        
-    # https://stackoverflow.com/questions/45132940/numpy-memmap-memory-usage-want-to-iterate-once/61472122#61472122                                                                                           
-    if split == 'train':                                                                                                                                                                                      
-        data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=np.uint16, mode='r')                                                                                                                      
-    else:                                                                                                                                                                                                     
-        data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=np.uint16, mode='r')                                                                                                                      
-    ix = torch.randint(len(data) - block_size, (batch_size,))                                                                                                                                                 
-    x = torch.stack([torch.from_numpy((data[i:i+block_size]).astype(np.int64)) for i in ix])                                                                                                                  
-    y = torch.stack([torch.from_numpy((data[i+1:i+1+block_size]).astype(np.int64)) for i in ix])
-    if device_type == 'cuda':                                                                                                                                                                                 
-        # pin arrays x,y, which allows us to move them to GPU asynchronously (non_blocking=True)                                                                                                              
-        x, y = x.pin_memory().to(device, non_blocking=True), y.pin_memory().to(device, non_blocking=True)                                                                                                     
-    else:                                                                                                                                                                                                     
-        x, y = x.to(device), y.to(device)                                                                                                                                                                     
-    return x, y                                                                                                                                                                                               
-                                                                                                                                                                                                            
-# init these up here, can override if init_from='resume' (i.e. from a checkpoint)                                                                                                                             
-iter_num = 0
-best_val_loss = 1e9                                                                                                                                                                                           
-                                                                                                                                                                                                              
-# attempt to derive vocab_size from the dataset
-meta_path = os.path.join(data_dir, 'meta.pkl')                                                                                                                                                                
-meta_vocab_size = None                                                                                                                                                                                        
-if os.path.exists(meta_path):
-    with open(meta_path, 'rb') as f:                                                                                                                                                                          
-        meta = pickle.load(f)                                                                                                                                                                                 
-    meta_vocab_size = meta['vocab_size']
-    print(f"found vocab_size = {meta_vocab_size} (inside {meta_path})")                                                                                                                                       
-                                                                                                                                                                                                              
-# model init
-model_args = dict(n_layer=n_layer, n_head=n_head, n_embd=n_embd, block_size=block_size,                                                                                                                       
-                  bias=bias, vocab_size=None, dropout=dropout) # start with model_args from command line                                                                                                      
-if init_from == 'scratch':                                                                                                                                                                                    
-    # init a new model from scratch                                                                                                                                                                           
-    print("Initializing a new model from scratch")                                                                                                                                                            
-    # determine the vocab size we'll use for from-scratch training                                                                                                                                            
-    if meta_vocab_size is None:                                                                                                                                                                               
-        print("defaulting to vocab_size of GPT-2 to 50304 (50257 rounded up for efficiency)")                                                                                                                 
-    model_args['vocab_size'] = meta_vocab_size if meta_vocab_size is not None else 50304                                                                                                                      
-    gptconf = GPTConfig(**model_args)                                                                                                                                                                       
-    model = GPT(gptconf)                                                                                                                                                                                      
-elif init_from == 'resume':                                                                                                                                                                                 
-    print(f"Resuming training from {out_dir}")                                                                                                                                                                
-    # resume training from a checkpoint.                                                                                                                                                                      
-    ckpt_path = os.path.join(out_dir, 'ckpt.pt')
-    checkpoint = torch.load(ckpt_path, map_location=device)                                                                                                                                                   
-    checkpoint_model_args = checkpoint['model_args']                                                                                                                                                        
-    # force these config attributes to be equal otherwise we can't even resume training                                                                                                                       
-    # the rest of the attributes (e.g. dropout) can stay as desired from command line                                                                                                                         
-    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:                                                                                                                             
-        model_args[k] = checkpoint_model_args[k]                                                                                                                                                              
-    # create the model                                                                                                                                                                                        
-    gptconf = GPTConfig(**model_args)                                                                                                                                                                       
-    model = GPT(gptconf)                                                                                                                                                                                      
-    state_dict = checkpoint['model']                                                                                                                                                                        
-    # fix the keys of the state dictionary :(                                                                                                                                                                 
-    # honestly no idea how checkpoints sometimes get this prefix, have to debug more                                                                                                                          
-    unwanted_prefix = '_orig_mod.'                                                                                                                                                                            
-    for k,v in list(state_dict.items()):                                                                                                                                                                      
-        if k.startswith(unwanted_prefix):                                                                                                                                                                     
-            state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)                                                                                                                                          
-    model.load_state_dict(state_dict)                                                                                                                                                                         
-    iter_num = checkpoint['iter_num']
-    best_val_loss = checkpoint['best_val_loss']                                                                                                                                                               
-elif init_from.startswith('gpt2'):                                                                                                                                                                          
-    print(f"Initializing from OpenAI GPT-2 weights: {init_from}")                                                                                                                                             
-    # initialize from OpenAI GPT-2 weights
-    override_args = dict(dropout=dropout)                                                                                                                                                                     
-    model = GPT.from_pretrained(init_from, override_args)                                                                                                                                                   
-    # read off the created config params, so we can store them into checkpoint correctly                                                                                                                      
-    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:                                                                                                                             
-        model_args[k] = getattr(model.config, k)                                                                                                                                                              
-# crop down the model block size if desired, using model surgery                                                                                                                                              
-if block_size < model.config.block_size:                                                                                                                                                                      
-    model.crop_block_size(block_size)                                                                                                                                                                         
-    model_args['block_size'] = block_size # so that the checkpoint will have the right value                                                                                                                  
-model.to(device)                                                                                                                                                                                              
 
-# initialize a GradScaler. If enabled=False scaler is a no-op                                                                                                                                                 
-scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))                                                                                                                                            
-                                                                                                                                                                                                              
-# optimizer                                                                                                                                                                                                 
-optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)                                                                                                              
-if init_from == 'resume':                                                                                                                                                                                     
-    optimizer.load_state_dict(checkpoint['optimizer'])                                                                                                                                                        
-checkpoint = None # free up memory                                                                                                                                                                            
-                                                                                                                                                                                                              
-# compile the model                                                                                                                                                                                         
-if compile:                                                                                                                                                                                                   
-    print("compiling the model... (takes a ~minute)")                                                                                                                                                       
-    unoptimized_model = model                                                                                                                                                                                 
-    model = torch.compile(model) # requires PyTorch 2.0
-                                                                                                                                                                                                              
-# wrap model into DDP container                                                                                                                                                                             
-if ddp:                                                                                                                                                                                                       
-    model = DDP(model, device_ids=[ddp_local_rank])                                                                                                                                                         
-                                                                                                                                                                                                              
-# helps estimate an arbitrarily accurate loss over either split using many batches                                                                                                                            
-@torch.no_grad()                                                                                                                                                                                              
-def estimate_loss():                                                                                                                                                                                          
-    out = {}                                                                                                                                                                                                  
-    model.eval()
-    for split in ['train', 'val']:                                                                                                                                                                            
-        losses = torch.zeros(eval_iters)                                                                                                                                                                    
-        for k in range(eval_iters):                                                                                                                                                                           
-            X, Y = get_batch(split)
-            with ctx:                                                                                                                                                                                         
-                logits, loss = model(X, Y)                                                                                                                                                                    
-            losses[k] = loss.item()
-        out[split] = losses.mean()                                                                                                                                                                            
-    model.train()                                                                                                                                                                                           
-    return out                                                                                                                                                                                                
 
-# learning rate decay scheduler (cosine with warmup)                                                                                                                                                          
-def get_lr(it):                                                                                                                                                                                             
-    # 1) linear warmup for warmup_iters steps                                                                                                                                                                 
-    if it < warmup_iters:
-        return learning_rate * (it + 1) / (warmup_iters + 1)                                                                                                                                                  
-    # 2) if it > lr_decay_iters, return min learning rate                                                                                                                                                     
-    if it > lr_decay_iters:                                                                                                                                                                                   
-        return min_lr                                                                                                                                                                                         
-    # 3) in between, use cosine decay down to min learning rate                                                                                                                                               
-    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)                                                                                                                                       
-    assert 0 <= decay_ratio <= 1
-    coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio)) # coeff ranges 0..1                                                                                                                                 
-    return min_lr + coeff * (learning_rate - min_lr)                                                                                                                                                          
-                                                                                                                                                                                                              
-# logging                                                                                                                                                                                                     
-if wandb_log and master_process:                                                                                                                                                                            
-    import wandb                                                                                                                                                                                              
-    wandb.init(project=wandb_project, name=wandb_run_name, config=config)
-                                                                                                                                                                                                              
-# training loop                                                                                                                                                                                             
-X, Y = get_batch('train') # fetch the very first batch                                                                                                                                                        
-t0 = time.time()                                                                                                                                                                                            
-local_iter_num = 0 # number of iterations in the lifetime of this process                                                                                                                                     
-raw_model = model.module if ddp else model # unwrap DDP container if needed
-running_mfu = -1.0                                                                                                                                                                                            
-while True:                                                                                                                                                                                                   
-                                                                                                                                                                                                              
-    # determine and set the learning rate for this iteration                                                                                                                                                  
-    lr = get_lr(iter_num) if decay_lr else learning_rate                                                                                                                                                    
-    for param_group in optimizer.param_groups:                                                                                                                                                                
-        param_group['lr'] = lr                                                                                                                                                                              
-                                                                                                                                                                                                              
-    # evaluate the loss on train/val sets and write checkpoints                                                                                                                                               
-    if iter_num % eval_interval == 0 and master_process:                                                                                                                                                      
-        losses = estimate_loss()                                                                                                                                                                              
-        print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")                                                                                                           
-        if wandb_log:                                                                                                                                                                                         
-            wandb.log({
-                "iter": iter_num,                                                                                                                                                                             
-                "train/loss": losses['train'],                                                                                                                                                              
-                "val/loss": losses['val'],                                                                                                                                                                    
-                "lr": lr,                                                                                                                                                                                   
-                "mfu": running_mfu*100,
-            })                                                                                                                                                                                                
-        if losses['val'] < best_val_loss:
-            best_val_loss = losses['val']                                                                                                                                                                     
-            if iter_num > 0:                                                                                                                                                                                  
-                ckpt = {
-                    'model': raw_model.state_dict(),                                                                                                                                                          
-                    'optimizer': optimizer.state_dict(),                                                                                                                                                      
-                    'model_args': model_args,
-                    'iter_num': iter_num,                                                                                                                                                                     
-                    'best_val_loss': best_val_loss,                                                                                                                                                         
-                    'config': config,
-                }                                                                                                                                                                                             
-                print(f"saving best checkpoint to {out_dir}")
-                torch.save(ckpt, os.path.join(out_dir, 'best.pt'))                                                                                                                                            
-    if iter_num == 0 and eval_only:                                                                                                                                                                           
-        break
-                                                                                                                                                                                                              
-    # forward backward update, with optional gradient accumulation to simulate larger batch size                                                                                                              
-    # and using the GradScaler if data type is float16                                                                                                                                                        
-    for micro_step in range(gradient_accumulation_steps):                                                                                                                                                     
-        if ddp:                                                                                                                                                                                               
-            model.require_backward_grad_sync = (micro_step == gradient_accumulation_steps - 1)
-        with ctx:                                                                                                                                                                                             
-            logits, loss = model(X, Y)                                                                                                                                                                      
-            loss = loss / gradient_accumulation_steps # scale the loss to account for gradient accumulation                                                                                                   
-        # immediately async prefetch next batch while model is doing the forward pass on the GPU                                                                                                            
-        X, Y = get_batch('train')                                                                                                                                                                             
-        # backward pass, with gradient scaling if training in fp16                                                                                                                                          
-        scaler.scale(loss).backward()                                                                                                                                                                         
-    # clip the gradient                                                                                                                                                                                     
-    if grad_clip != 0.0:                                                                                                                                                                                      
-        scaler.unscale_(optimizer)                                                                                                                                                                          
-        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)                                                                                                                                         
-    # step the optimizer and scaler if training in fp16                                                                                                                                                       
-    scaler.step(optimizer)
-    scaler.update()                                                                                                                                                                                           
-    # flush the gradients as soon as we can, no need for this memory anymore                                                                                                                                
-    optimizer.zero_grad(set_to_none=True)                                                                                                                                                                     
-                                                                                                                                                                                                              
-    # timing and logging                                                                                                                                                                                      
-    t1 = time.time()                                                                                                                                                                                          
-    dt = t1 - t0                                                                                                                                                                                            
-    t0 = t1
-    if iter_num % log_interval == 0 and master_process:                                                                                                                                                       
-        lossf = loss.item() * gradient_accumulation_steps
-        if local_iter_num >= 5:                                                                                                                                                                               
-            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)                                                                                                                      
-            running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu                                                                                                                           
-        print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")                                                                                                         
-        if wandb_log and master_process:                                                                                                                                                                      
-            wandb.log({                                                                                                                                                                                       
-                "iter": iter_num,                                                                                                                                                                             
-                "train/loss": lossf,                                                                                                                                                                        
-                "lr": lr,                                                                                                                                                                                     
-                "mfu": running_mfu * 100,
-            })                                                                                                                                                                                                
-                                                                                                                                                                                                            
-    # periodic checkpoint
-    if iter_num > 0 and iter_num % checkpoint_interval == 0 and master_process:
-        ckpt = {                                                                                                                                                                                              
-            'model': raw_model.state_dict(),
-            'optimizer': optimizer.state_dict(),                                                                                                                                                              
-            'model_args': model_args,                                                                                                                                                                       
-            'iter_num': iter_num,
-            'best_val_loss': best_val_loss,                                                                                                                                                                   
-            'config': config,
-        }                                                                                                                                                                                                     
-        ckpt_path = os.path.join(out_dir, f'ckpt_{iter_num:07d}.pt')                                                                                                                                        
-        print(f"saving periodic checkpoint to {ckpt_path}")
-        torch.save(ckpt, ckpt_path)                                                                                                                                                                           
+@hydra.main(version_base=None, config_path="config", config_name="config")
+def main(cfg: DictConfig):
+    print(OmegaConf.to_yaml(cfg))
 
-    iter_num += 1                                                                                                                                                                                             
-    local_iter_num += 1                                                                                                                                                                                     
-                                                                                                                                                                                                              
-    # termination conditions                                                                                                                                                                                
-    if iter_num > max_iters:
-        break
+    ddp = int(os.environ.get("RANK", -1)) != -1
+    if ddp:
+        init_process_group(backend="nccl")
+        ddp_rank = int(os.environ["RANK"])
+        ddp_local_rank = int(os.environ["LOCAL_RANK"])
+        ddp_world_size = int(os.environ["WORLD_SIZE"])
+        device = f"cuda:{ddp_local_rank}"
+        torch.cuda.set_device(device)
+        master_process = ddp_rank == 0
+        seed_offset = ddp_rank
+        cfg.data.gradient_accumulation_steps //= ddp_world_size
+    else:
+        master_process = True
+        seed_offset = 0
+        ddp_world_size = 1
 
-# save last checkpoint                                                                                                                                                                                        
-if master_process:
-    ckpt = {                                                                                                                                                                                                  
-        'model': raw_model.state_dict(),                                                                                                                                                                    
-        'optimizer': optimizer.state_dict(),
-        'model_args': model_args,
-        'iter_num': iter_num,
-        'best_val_loss': best_val_loss,
-        'config': config,                                                                                                                                                                                     
-    }
-    print(f"saving last checkpoint to {out_dir}")                                                                                                                                                             
-    torch.save(ckpt, os.path.join(out_dir, 'last.pt'))                                                                                                                                                      
-                                                                                                                                                                                                              
-if ddp:
-    destroy_process_group() 
+    tokens_per_iter = cfg.data.gradient_accumulation_steps * ddp_world_size * cfg.data.batch_size * cfg.model.block_size
+    print(f"tokens per iteration will be: {tokens_per_iter:,}")
+
+    if master_process:
+        os.makedirs(cfg.out_dir, exist_ok=True)
+
+    set_seed(cfg.seed + seed_offset)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = "bfloat16" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "float16"
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    device_type = "cuda" if "cuda" in device else "cpu"
+    ptdtype = {"float32": torch.float32, "bfloat16": torch.bfloat16, "float16": torch.float16}[dtype]
+    ctx = nullcontext() if device_type == "cpu" else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
+
+    data_dir = os.path.join("data", cfg.data.dataset)
+
+    def get_batch(split):
+        if split == "train":
+            data = np.memmap(os.path.join(data_dir, "train.bin"), dtype=np.uint16, mode="r")
+        else:
+            data = np.memmap(os.path.join(data_dir, "val.bin"), dtype=np.uint16, mode="r")
+        ix = torch.randint(len(data) - cfg.model.block_size, (cfg.data.batch_size,))
+        x = torch.stack([torch.from_numpy((data[i:i+cfg.model.block_size]).astype(np.int64)) for i in ix])
+        y = torch.stack([torch.from_numpy((data[i+1:i+1+cfg.model.block_size]).astype(np.int64)) for i in ix])
+        if device_type == "cuda":
+            x, y = x.pin_memory().to(device, non_blocking=True), y.pin_memory().to(device, non_blocking=True)
+        else:
+            x, y = x.to(device), y.to(device)
+        return x, y
+
+    iter_num = 0
+    best_val_loss = 1e9
+
+    meta_path = os.path.join(data_dir, "meta.pkl")
+    meta_vocab_size = None
+    if os.path.exists(meta_path):
+        with open(meta_path, "rb") as f:
+            meta = pickle.load(f)
+        meta_vocab_size = meta["vocab_size"]
+        print(f"found vocab_size = {meta_vocab_size} (inside {meta_path})")
+
+    model_args = dict(
+        n_layer=cfg.model.n_layer,
+        n_head=cfg.model.n_head,
+        n_embd=cfg.model.n_embd,
+        block_size=cfg.model.block_size,
+        bias=cfg.model.bias,
+        vocab_size=meta_vocab_size if meta_vocab_size is not None else 50304,
+        dropout=cfg.model.dropout,
+    )
+    print("Initializing a new model from scratch")
+    gptconf = GPTConfig(**model_args)
+    model = GPT(gptconf)
+    model.to(device)
+
+    scaler = torch.cuda.amp.GradScaler(enabled=(dtype == "float16"))
+    optimizer = model.configure_optimizers(
+        cfg.optim.weight_decay,
+        cfg.optim.learning_rate,
+        (cfg.optim.beta1, cfg.optim.beta2),
+        device_type,
+    )
+
+    if cfg.compile:
+        print("compiling the model...")
+        model = torch.compile(model)
+
+    if ddp:
+        model = DDP(model, device_ids=[ddp_local_rank])
+
+    @torch.no_grad()
+    def estimate_loss():
+        out = {}
+        model.eval()
+        for split in ["train", "val"]:
+            losses = torch.zeros(cfg.eval_iters)
+            for k in range(cfg.eval_iters):
+                X, Y = get_batch(split)
+                with ctx:
+                    logits, loss = model(X, Y)
+                losses[k] = loss.item()
+            out[split] = losses.mean()
+        model.train()
+        return out
+
+    def get_lr(it):
+        if it < cfg.optim.warmup_iters:
+            return cfg.optim.learning_rate * (it + 1) / (cfg.optim.warmup_iters + 1)
+        if it > cfg.optim.lr_decay_iters:
+            return cfg.optim.min_lr
+        decay_ratio = (it - cfg.optim.warmup_iters) / (cfg.optim.lr_decay_iters - cfg.optim.warmup_iters)
+        coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))
+        return cfg.optim.min_lr + coeff * (cfg.optim.learning_rate - cfg.optim.min_lr)
+
+    hydra_cfg_path = os.path.join(os.getcwd(), ".hydra", "config.yaml")
+
+    if cfg.wandb_log and master_process:
+        import wandb
+        wandb.init(
+            project=cfg.wandb_project,
+            name=cfg.wandb_run_name,
+            config=OmegaConf.to_container(cfg, resolve=True),
+            notes=f"hydra config: {hydra_cfg_path}",
+        )
+
+    raw_model = model.module if ddp else model
+    X, Y = get_batch("train")
+    t0 = time.time()
+    local_iter_num = 0
+    running_mfu = -1.0
+
+    while True:
+        lr = get_lr(iter_num) if cfg.optim.decay_lr else cfg.optim.learning_rate
+        for param_group in optimizer.param_groups:
+            param_group["lr"] = lr
+
+        if iter_num % cfg.eval_interval == 0 and master_process:
+            losses = estimate_loss()
+            print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
+            if cfg.wandb_log:
+                import wandb
+                wandb.log({"iter": iter_num, "train/loss": losses["train"], "val/loss": losses["val"], "lr": lr})
+            if losses["val"] < best_val_loss:
+                best_val_loss = losses["val"]
+                if iter_num > 0:
+                    ckpt = {"model": raw_model.state_dict(), "optimizer": optimizer.state_dict(),
+                            "model_args": model_args, "iter_num": iter_num, "best_val_loss": best_val_loss,
+                            "config": OmegaConf.to_container(cfg)}
+                    torch.save(ckpt, os.path.join(cfg.out_dir, "best.pt"))
+
+        if iter_num == 0 and cfg.eval_only:
+            break
+
+        for micro_step in range(cfg.data.gradient_accumulation_steps):
+            if ddp:
+                model.require_backward_grad_sync = (micro_step == cfg.data.gradient_accumulation_steps - 1)
+            with ctx:
+                logits, loss = model(X, Y)
+                loss = loss / cfg.data.gradient_accumulation_steps
+            X, Y = get_batch("train")
+            scaler.scale(loss).backward()
+
+        if cfg.optim.grad_clip != 0.0:
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(model.parameters(), cfg.optim.grad_clip)
+        scaler.step(optimizer)
+        scaler.update()
+        optimizer.zero_grad(set_to_none=True)
+
+        t1 = time.time()
+        dt = t1 - t0
+        t0 = t1
+        if iter_num % cfg.log_interval == 0 and master_process:
+            lossf = loss.item() * cfg.data.gradient_accumulation_steps
+            if local_iter_num >= 5:
+                mfu = raw_model.estimate_mfu(cfg.data.batch_size * cfg.data.gradient_accumulation_steps, dt)
+                running_mfu = mfu if running_mfu == -1.0 else 0.9 * running_mfu + 0.1 * mfu
+            print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
+            if cfg.wandb_log and master_process:
+                import wandb
+                wandb.log({"iter": iter_num, "train/loss": lossf, "lr": lr, "mfu": running_mfu * 100})
+
+        if iter_num > 0 and iter_num % cfg.checkpoint_interval == 0 and master_process:
+            ckpt = {"model": raw_model.state_dict(), "optimizer": optimizer.state_dict(),
+                    "model_args": model_args, "iter_num": iter_num, "best_val_loss": best_val_loss,
+                    "config": OmegaConf.to_container(cfg)}
+            ckpt_path = os.path.join(cfg.out_dir, f"ckpt_{iter_num:07d}.pt")
+            print(f"saving periodic checkpoint to {ckpt_path}")
+            torch.save(ckpt, ckpt_path)
+
+        iter_num += 1
+        local_iter_num += 1
+
+        if iter_num > cfg.optim.max_iters:
+            break
+
+    if master_process:
+        ckpt = {"model": raw_model.state_dict(), "optimizer": optimizer.state_dict(),
+                "model_args": model_args, "iter_num": iter_num, "best_val_loss": best_val_loss,
+                "config": OmegaConf.to_container(cfg)}
+        torch.save(ckpt, os.path.join(cfg.out_dir, "last.pt"))
+        print(f"saving last checkpoint to {cfg.out_dir}")
+
+    if ddp:
+        destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/train.py
+++ b/train.py
@@ -97,6 +97,12 @@ def main(cfg: DictConfig):
         bias=cfg.model.bias,
         vocab_size=meta_vocab_size if meta_vocab_size is not None else 50304,
         dropout=cfg.model.dropout,
+        activation=cfg.model.activation,
+        norm_position=cfg.model.norm_position,
+        use_moe=cfg.model.use_moe,
+        moe_n_experts=cfg.model.moe_n_experts,
+        moe_top_k=cfg.model.moe_top_k,
+        moe_aux_loss_weight=cfg.model.moe_aux_loss_weight,
     )
     print("Initializing a new model from scratch")
     gptconf = GPTConfig(**model_args)
@@ -109,6 +115,8 @@ def main(cfg: DictConfig):
         cfg.optim.learning_rate,
         (cfg.optim.beta1, cfg.optim.beta2),
         device_type,
+        cfg.optim.name,
+        cfg.optim.momentum,
     )
 
     if cfg.compile:
@@ -146,11 +154,16 @@ def main(cfg: DictConfig):
 
     if cfg.wandb_log and master_process:
         import wandb
+        run_notes = f"hydra config: {hydra_cfg_path}"
+        if cfg.wandb_notes:
+            run_notes = f"{cfg.wandb_notes}\n{run_notes}"
         wandb.init(
             project=cfg.wandb_project,
             name=cfg.wandb_run_name,
+            group=cfg.wandb_group,
+            tags=list(cfg.wandb_tags),
             config=OmegaConf.to_container(cfg, resolve=True),
-            notes=f"hydra config: {hydra_cfg_path}",
+            notes=run_notes,
         )
 
     raw_model = model.module if ddp else model
@@ -169,7 +182,11 @@ def main(cfg: DictConfig):
             print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
             if cfg.wandb_log:
                 import wandb
-                wandb.log({"iter": iter_num, "train/loss": losses["train"], "val/loss": losses["val"], "lr": lr})
+                aux_loss = getattr(raw_model, "last_aux_loss", None)
+                log_payload = {"iter": iter_num, "train/loss": losses["train"], "val/loss": losses["val"], "lr": lr}
+                if aux_loss is not None:
+                    log_payload["moe/aux_loss"] = float(aux_loss.item())
+                wandb.log(log_payload)
             if losses["val"] < best_val_loss:
                 best_val_loss = losses["val"]
                 if iter_num > 0:
@@ -208,7 +225,14 @@ def main(cfg: DictConfig):
             print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
             if cfg.wandb_log and master_process:
                 import wandb
-                wandb.log({"iter": iter_num, "train/loss": lossf, "lr": lr, "mfu": running_mfu * 100})
+                aux_loss = getattr(raw_model, "last_aux_loss", None)
+                ce_loss = getattr(raw_model, "last_ce_loss", None)
+                log_payload = {"iter": iter_num, "train/loss": lossf, "lr": lr, "mfu": running_mfu * 100}
+                if ce_loss is not None:
+                    log_payload["train/ce_loss"] = float(ce_loss.item())
+                if aux_loss is not None:
+                    log_payload["moe/aux_loss"] = float(aux_loss.item())
+                wandb.log(log_payload)
 
         if iter_num > 0 and iter_num % cfg.checkpoint_interval == 0 and master_process:
             ckpt = {"model": raw_model.state_dict(), "optimizer": optimizer.state_dict(),

--- a/train.py
+++ b/train.py
@@ -1,336 +1,377 @@
-"""
-This training script can be run both on a single gpu in debug mode,
+"""                                                                                                                                                                                                           
+This training script can be run both on a single gpu in debug mode,                                                                                                                                         
 and also in a larger training run with distributed data parallel (ddp).
-
+                                                                                                                                                                                                              
 To run on a single GPU, example:
-$ python train.py --batch_size=32 --compile=False
-
-To run with DDP on 4 gpus on 1 node, example:
-$ torchrun --standalone --nproc_per_node=4 train.py
-
-To run with DDP on 4 gpus across 2 nodes, example:
-- Run on the first (master) node with example IP 123.456.123.456:
-$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 --master_addr=123.456.123.456 --master_port=1234 train.py
-- Run on the worker node:
-$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123.456 --master_port=1234 train.py
-(If your cluster does not have Infiniband interconnect prepend NCCL_IB_DISABLE=1)
-"""
-
-import os
+$ python train.py --batch_size=32 --compile=False                                                                                                                                                             
+                                                                                                                                                                                                              
+To run with DDP on 4 gpus on 1 node, example:                                                                                                                                                                 
+$ torchrun --standalone --nproc_per_node=4 train.py                                                                                                                                                           
+                                                                                                                                                                                                              
+To run with DDP on 4 gpus across 2 nodes, example:                                                                                                                                                          
+- Run on the first (master) node with example IP 123.456.123.456:                                                                                                                                             
+$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 --master_addr=123.456.123.456 --master_port=1234 train.py                                                                                              
+- Run on the worker node:                                                                                                                                                                                     
+$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123.456 --master_port=1234 train.py                                                                                              
+(If your cluster does not have Infiniband interconnect prepend NCCL_IB_DISABLE=1)                                                                                                                             
+"""                                                                                                                                                                                                           
+                                                                                                                                                                                                              
+import os                                                                                                                                                                                                     
+import random                                                                                                                                                                                               
 import time
 import math
 import pickle
 from contextlib import nullcontext
-
+                                                                                                                                                                                                              
 import numpy as np
-import torch
-from torch.nn.parallel import DistributedDataParallel as DDP
+import torch                                                                                                                                                                                                  
+from torch.nn.parallel import DistributedDataParallel as DDP                                                                                                                                                
 from torch.distributed import init_process_group, destroy_process_group
-
-from model import GPTConfig, GPT
-
-# -----------------------------------------------------------------------------
-# default config values designed to train a gpt2 (124M) on OpenWebText
-# I/O
-out_dir = 'out'
-eval_interval = 2000
-log_interval = 1
-eval_iters = 200
+                                                                                                                                                                                                              
+from model import GPTConfig, GPT                                                                                                                                                                              
+                                                                                                                                                                                                              
+# -----------------------------------------------------------------------------                                                                                                                               
+# default config values designed to train a gpt2 (124M) on OpenWebText                                                                                                                                      
+# I/O                                                                                                                                                                                                         
+out_dir = '/root/autodl-tmp/ckpt'                                                                                                                                                                             
+eval_interval = 2000                                                                                                                                                                                          
+log_interval = 1                                                                                                                                                                                              
+eval_iters = 200                                                                                                                                                                                            
 eval_only = False # if True, script exits right after the first eval
-always_save_checkpoint = True # if True, always save a checkpoint after each eval
-init_from = 'scratch' # 'scratch' or 'resume' or 'gpt2*'
-# wandb logging
-wandb_log = False # disabled by default
-wandb_project = 'owt'
-wandb_run_name = 'gpt2' # 'run' + str(time.time())
-# data
-dataset = 'openwebtext'
-gradient_accumulation_steps = 5 * 8 # used to simulate larger batch sizes
-batch_size = 12 # if gradient_accumulation_steps > 1, this is the micro-batch size
-block_size = 1024
-# model
-n_layer = 12
-n_head = 12
-n_embd = 768
-dropout = 0.0 # for pretraining 0 is good, for finetuning try 0.1+
-bias = False # do we use bias inside LayerNorm and Linear layers?
-# adamw optimizer
-learning_rate = 6e-4 # max learning rate
-max_iters = 600000 # total number of training iterations
-weight_decay = 1e-1
-beta1 = 0.9
-beta2 = 0.95
-grad_clip = 1.0 # clip gradients at this value, or disable if == 0.0
-# learning rate decay settings
-decay_lr = True # whether to decay the learning rate
-warmup_iters = 2000 # how many steps to warm up for
-lr_decay_iters = 600000 # should be ~= max_iters per Chinchilla
-min_lr = 6e-5 # minimum learning rate, should be ~= learning_rate/10 per Chinchilla
-# DDP settings
-backend = 'nccl' # 'nccl', 'gloo', etc.
-# system
-device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks
-dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler
-compile = True # use PyTorch 2.0 to compile the model to be faster
-# -----------------------------------------------------------------------------
-config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
-exec(open('configurator.py').read()) # overrides from command line or config file
-config = {k: globals()[k] for k in config_keys} # will be useful for logging
-# -----------------------------------------------------------------------------
-
-# various inits, derived attributes, I/O setup
+always_save_checkpoint = True # if True, always save a checkpoint after each eval                                                                                                                             
+checkpoint_interval = 500  # save a periodic checkpoint every N iters
+seed = 1337  # random seed for reproducibility                                                                                                                                                                
+init_from = 'scratch' # 'scratch' or 'resume' or 'gpt2*'                                                                                                                                                      
+# wandb logging                                                                                                                                                                                               
+wandb_log = False # disabled by default                                                                                                                                                                       
+wandb_project = 'owt'                                                                                                                                                                                         
+wandb_run_name = 'gpt2' # 'run' + str(time.time())                                                                                                                                                          
+# data                                                                                                                                                                                                        
+dataset = 'openwebtext'                                                                                                                                                                                     
+gradient_accumulation_steps = 5 * 8 # used to simulate larger batch sizes                                                                                                                                     
+batch_size = 12 # if gradient_accumulation_steps > 1, this is the micro-batch size                                                                                                                            
+block_size = 1024                                                                                                                                                                                             
+# model                                                                                                                                                                                                       
+n_layer = 12                                                                                                                                                                                                  
+n_head = 12                                                                                                                                                                                                 
+n_embd = 768                                                                                                                                                                                                  
+dropout = 0.0 # for pretraining 0 is good, for finetuning try 0.1+                                                                                                                                          
+bias = False # do we use bias inside LayerNorm and Linear layers?                                                                                                                                             
+# adamw optimizer                                                                                                                                                                                             
+learning_rate = 6e-4 # max learning rate                                                                                                                                                                      
+max_iters = 600000 # total number of training iterations                                                                                                                                                      
+weight_decay = 1e-1                                                                                                                                                                                           
+beta1 = 0.9                                                                                                                                                                                                   
+beta2 = 0.95                                                                                                                                                                                                  
+grad_clip = 1.0 # clip gradients at this value, or disable if == 0.0                                                                                                                                        
+# learning rate decay settings                                                                                                                                                                                
+decay_lr = True # whether to decay the learning rate                                                                                                                                                          
+warmup_iters = 2000 # how many steps to warm up for                                                                                                                                                           
+lr_decay_iters = 600000 # should be ~= max_iters per Chinchilla                                                                                                                                               
+min_lr = 6e-5 # minimum learning rate, should be ~= learning_rate/10 per Chinchilla                                                                                                                           
+# DDP settings                                                                                                                                                                                                
+backend = 'nccl' # 'nccl', 'gloo', etc.                                                                                                                                                                       
+# system                                                                                                                                                                                                      
+device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1' etc., or try 'mps' on macbooks                                                                                                                
+dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32', 'bfloat16', or 'float16', the latter will auto implement a GradScaler                          
+compile = True # use PyTorch 2.0 to compile the model to be faster                                                                                                                                            
+# -----------------------------------------------------------------------------                                                                                                                               
+config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]                                                                                            
+exec(open('configurator.py').read()) # overrides from command line or config file                                                                                                                             
+config = {k: globals()[k] for k in config_keys} # will be useful for logging                                                                                                                                  
+# -----------------------------------------------------------------------------                                                                                                                               
+                                                                                                                                                                                                              
+def set_seed(s):                                                                                                                                                                                              
+    random.seed(s)                                                                                                                                                                                          
+    np.random.seed(s)                                                                                                                                                                                         
+    torch.manual_seed(s)                                                                                                                                                                                    
+    torch.cuda.manual_seed_all(s)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False                                                                                                                                                                    
+    os.environ["PYTHONHASHSEED"] = str(s)
+                                                                                                                                                                                                              
+# various inits, derived attributes, I/O setup                                                                                                                                                                
 ddp = int(os.environ.get('RANK', -1)) != -1 # is this a ddp run?
-if ddp:
-    init_process_group(backend=backend)
-    ddp_rank = int(os.environ['RANK'])
-    ddp_local_rank = int(os.environ['LOCAL_RANK'])
+if ddp:                                                                                                                                                                                                       
+    init_process_group(backend=backend)                                                                                                                                                                     
+    ddp_rank = int(os.environ['RANK'])                                                                                                                                                                        
+    ddp_local_rank = int(os.environ['LOCAL_RANK'])                                                                                                                                                            
     ddp_world_size = int(os.environ['WORLD_SIZE'])
-    device = f'cuda:{ddp_local_rank}'
-    torch.cuda.set_device(device)
-    master_process = ddp_rank == 0 # this process will do logging, checkpointing etc.
-    seed_offset = ddp_rank # each process gets a different seed
-    # world_size number of processes will be training simultaneously, so we can scale
-    # down the desired gradient accumulation iterations per process proportionally
-    assert gradient_accumulation_steps % ddp_world_size == 0
-    gradient_accumulation_steps //= ddp_world_size
-else:
-    # if not ddp, we are running on a single gpu, and one process
-    master_process = True
+    device = f'cuda:{ddp_local_rank}'                                                                                                                                                                         
+    torch.cuda.set_device(device)                                                                                                                                                                           
+    master_process = ddp_rank == 0 # this process will do logging, checkpointing etc.                                                                                                                         
+    seed_offset = ddp_rank # each process gets a different seed                                                                                                                                               
+    # world_size number of processes will be training simultaneously, so we can scale                                                                                                                         
+    # down the desired gradient accumulation iterations per process proportionally                                                                                                                            
+    assert gradient_accumulation_steps % ddp_world_size == 0                                                                                                                                                  
+    gradient_accumulation_steps //= ddp_world_size                                                                                                                                                            
+else:                                                                                                                                                                                                         
+    # if not ddp, we are running on a single gpu, and one process                                                                                                                                             
+    master_process = True                                                                                                                                                                                     
     seed_offset = 0
-    ddp_world_size = 1
-tokens_per_iter = gradient_accumulation_steps * ddp_world_size * batch_size * block_size
+    ddp_world_size = 1                                                                                                                                                                                        
+tokens_per_iter = gradient_accumulation_steps * ddp_world_size * batch_size * block_size                                                                                                                      
 print(f"tokens per iteration will be: {tokens_per_iter:,}")
-
-if master_process:
-    os.makedirs(out_dir, exist_ok=True)
-torch.manual_seed(1337 + seed_offset)
+                                                                                                                                                                                                              
+if master_process:                                                                                                                                                                                          
+    os.makedirs(out_dir, exist_ok=True)                                                                                                                                                                       
+set_seed(seed + seed_offset)                                                                                                                                                                                  
 torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
-torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
-device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast
-# note: float16 data type will automatically use a GradScaler
-ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
-ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
-
-# poor man's data loader
-data_dir = os.path.join('data', dataset)
-def get_batch(split):
-    # We recreate np.memmap every batch to avoid a memory leak, as per
-    # https://stackoverflow.com/questions/45132940/numpy-memmap-memory-usage-want-to-iterate-once/61472122#61472122
-    if split == 'train':
-        data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=np.uint16, mode='r')
-    else:
-        data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=np.uint16, mode='r')
-    ix = torch.randint(len(data) - block_size, (batch_size,))
-    x = torch.stack([torch.from_numpy((data[i:i+block_size]).astype(np.int64)) for i in ix])
+torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn                                                                                                                                                  
+device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast                                                                                                                       
+# note: float16 data type will automatically use a GradScaler                                                                                                                                                 
+ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]                                                                                                             
+ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)                                                                                                   
+                                                                                                                                                                                                              
+# poor man's data loader                                                                                                                                                                                      
+data_dir = os.path.join('data', dataset)                                                                                                                                                                      
+def get_batch(split):                                                                                                                                                                                         
+    # We recreate np.memmap every batch to avoid a memory leak, as per                                                                                                                                        
+    # https://stackoverflow.com/questions/45132940/numpy-memmap-memory-usage-want-to-iterate-once/61472122#61472122                                                                                           
+    if split == 'train':                                                                                                                                                                                      
+        data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=np.uint16, mode='r')                                                                                                                      
+    else:                                                                                                                                                                                                     
+        data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=np.uint16, mode='r')                                                                                                                      
+    ix = torch.randint(len(data) - block_size, (batch_size,))                                                                                                                                                 
+    x = torch.stack([torch.from_numpy((data[i:i+block_size]).astype(np.int64)) for i in ix])                                                                                                                  
     y = torch.stack([torch.from_numpy((data[i+1:i+1+block_size]).astype(np.int64)) for i in ix])
-    if device_type == 'cuda':
-        # pin arrays x,y, which allows us to move them to GPU asynchronously (non_blocking=True)
-        x, y = x.pin_memory().to(device, non_blocking=True), y.pin_memory().to(device, non_blocking=True)
-    else:
-        x, y = x.to(device), y.to(device)
-    return x, y
-
-# init these up here, can override if init_from='resume' (i.e. from a checkpoint)
+    if device_type == 'cuda':                                                                                                                                                                                 
+        # pin arrays x,y, which allows us to move them to GPU asynchronously (non_blocking=True)                                                                                                              
+        x, y = x.pin_memory().to(device, non_blocking=True), y.pin_memory().to(device, non_blocking=True)                                                                                                     
+    else:                                                                                                                                                                                                     
+        x, y = x.to(device), y.to(device)                                                                                                                                                                     
+    return x, y                                                                                                                                                                                               
+                                                                                                                                                                                                            
+# init these up here, can override if init_from='resume' (i.e. from a checkpoint)                                                                                                                             
 iter_num = 0
-best_val_loss = 1e9
-
+best_val_loss = 1e9                                                                                                                                                                                           
+                                                                                                                                                                                                              
 # attempt to derive vocab_size from the dataset
-meta_path = os.path.join(data_dir, 'meta.pkl')
-meta_vocab_size = None
+meta_path = os.path.join(data_dir, 'meta.pkl')                                                                                                                                                                
+meta_vocab_size = None                                                                                                                                                                                        
 if os.path.exists(meta_path):
-    with open(meta_path, 'rb') as f:
-        meta = pickle.load(f)
+    with open(meta_path, 'rb') as f:                                                                                                                                                                          
+        meta = pickle.load(f)                                                                                                                                                                                 
     meta_vocab_size = meta['vocab_size']
-    print(f"found vocab_size = {meta_vocab_size} (inside {meta_path})")
-
+    print(f"found vocab_size = {meta_vocab_size} (inside {meta_path})")                                                                                                                                       
+                                                                                                                                                                                                              
 # model init
-model_args = dict(n_layer=n_layer, n_head=n_head, n_embd=n_embd, block_size=block_size,
-                  bias=bias, vocab_size=None, dropout=dropout) # start with model_args from command line
-if init_from == 'scratch':
-    # init a new model from scratch
-    print("Initializing a new model from scratch")
-    # determine the vocab size we'll use for from-scratch training
-    if meta_vocab_size is None:
-        print("defaulting to vocab_size of GPT-2 to 50304 (50257 rounded up for efficiency)")
-    model_args['vocab_size'] = meta_vocab_size if meta_vocab_size is not None else 50304
-    gptconf = GPTConfig(**model_args)
-    model = GPT(gptconf)
-elif init_from == 'resume':
-    print(f"Resuming training from {out_dir}")
-    # resume training from a checkpoint.
+model_args = dict(n_layer=n_layer, n_head=n_head, n_embd=n_embd, block_size=block_size,                                                                                                                       
+                  bias=bias, vocab_size=None, dropout=dropout) # start with model_args from command line                                                                                                      
+if init_from == 'scratch':                                                                                                                                                                                    
+    # init a new model from scratch                                                                                                                                                                           
+    print("Initializing a new model from scratch")                                                                                                                                                            
+    # determine the vocab size we'll use for from-scratch training                                                                                                                                            
+    if meta_vocab_size is None:                                                                                                                                                                               
+        print("defaulting to vocab_size of GPT-2 to 50304 (50257 rounded up for efficiency)")                                                                                                                 
+    model_args['vocab_size'] = meta_vocab_size if meta_vocab_size is not None else 50304                                                                                                                      
+    gptconf = GPTConfig(**model_args)                                                                                                                                                                       
+    model = GPT(gptconf)                                                                                                                                                                                      
+elif init_from == 'resume':                                                                                                                                                                                 
+    print(f"Resuming training from {out_dir}")                                                                                                                                                                
+    # resume training from a checkpoint.                                                                                                                                                                      
     ckpt_path = os.path.join(out_dir, 'ckpt.pt')
-    checkpoint = torch.load(ckpt_path, map_location=device)
-    checkpoint_model_args = checkpoint['model_args']
-    # force these config attributes to be equal otherwise we can't even resume training
-    # the rest of the attributes (e.g. dropout) can stay as desired from command line
-    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:
-        model_args[k] = checkpoint_model_args[k]
-    # create the model
-    gptconf = GPTConfig(**model_args)
-    model = GPT(gptconf)
-    state_dict = checkpoint['model']
-    # fix the keys of the state dictionary :(
-    # honestly no idea how checkpoints sometimes get this prefix, have to debug more
-    unwanted_prefix = '_orig_mod.'
-    for k,v in list(state_dict.items()):
-        if k.startswith(unwanted_prefix):
-            state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)
-    model.load_state_dict(state_dict)
+    checkpoint = torch.load(ckpt_path, map_location=device)                                                                                                                                                   
+    checkpoint_model_args = checkpoint['model_args']                                                                                                                                                        
+    # force these config attributes to be equal otherwise we can't even resume training                                                                                                                       
+    # the rest of the attributes (e.g. dropout) can stay as desired from command line                                                                                                                         
+    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:                                                                                                                             
+        model_args[k] = checkpoint_model_args[k]                                                                                                                                                              
+    # create the model                                                                                                                                                                                        
+    gptconf = GPTConfig(**model_args)                                                                                                                                                                       
+    model = GPT(gptconf)                                                                                                                                                                                      
+    state_dict = checkpoint['model']                                                                                                                                                                        
+    # fix the keys of the state dictionary :(                                                                                                                                                                 
+    # honestly no idea how checkpoints sometimes get this prefix, have to debug more                                                                                                                          
+    unwanted_prefix = '_orig_mod.'                                                                                                                                                                            
+    for k,v in list(state_dict.items()):                                                                                                                                                                      
+        if k.startswith(unwanted_prefix):                                                                                                                                                                     
+            state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)                                                                                                                                          
+    model.load_state_dict(state_dict)                                                                                                                                                                         
     iter_num = checkpoint['iter_num']
-    best_val_loss = checkpoint['best_val_loss']
-elif init_from.startswith('gpt2'):
-    print(f"Initializing from OpenAI GPT-2 weights: {init_from}")
+    best_val_loss = checkpoint['best_val_loss']                                                                                                                                                               
+elif init_from.startswith('gpt2'):                                                                                                                                                                          
+    print(f"Initializing from OpenAI GPT-2 weights: {init_from}")                                                                                                                                             
     # initialize from OpenAI GPT-2 weights
-    override_args = dict(dropout=dropout)
-    model = GPT.from_pretrained(init_from, override_args)
-    # read off the created config params, so we can store them into checkpoint correctly
-    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:
-        model_args[k] = getattr(model.config, k)
-# crop down the model block size if desired, using model surgery
-if block_size < model.config.block_size:
-    model.crop_block_size(block_size)
-    model_args['block_size'] = block_size # so that the checkpoint will have the right value
-model.to(device)
+    override_args = dict(dropout=dropout)                                                                                                                                                                     
+    model = GPT.from_pretrained(init_from, override_args)                                                                                                                                                   
+    # read off the created config params, so we can store them into checkpoint correctly                                                                                                                      
+    for k in ['n_layer', 'n_head', 'n_embd', 'block_size', 'bias', 'vocab_size']:                                                                                                                             
+        model_args[k] = getattr(model.config, k)                                                                                                                                                              
+# crop down the model block size if desired, using model surgery                                                                                                                                              
+if block_size < model.config.block_size:                                                                                                                                                                      
+    model.crop_block_size(block_size)                                                                                                                                                                         
+    model_args['block_size'] = block_size # so that the checkpoint will have the right value                                                                                                                  
+model.to(device)                                                                                                                                                                                              
 
-# initialize a GradScaler. If enabled=False scaler is a no-op
-scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
-
-# optimizer
-optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)
-if init_from == 'resume':
-    optimizer.load_state_dict(checkpoint['optimizer'])
-checkpoint = None # free up memory
-
-# compile the model
-if compile:
-    print("compiling the model... (takes a ~minute)")
-    unoptimized_model = model
+# initialize a GradScaler. If enabled=False scaler is a no-op                                                                                                                                                 
+scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))                                                                                                                                            
+                                                                                                                                                                                                              
+# optimizer                                                                                                                                                                                                 
+optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)                                                                                                              
+if init_from == 'resume':                                                                                                                                                                                     
+    optimizer.load_state_dict(checkpoint['optimizer'])                                                                                                                                                        
+checkpoint = None # free up memory                                                                                                                                                                            
+                                                                                                                                                                                                              
+# compile the model                                                                                                                                                                                         
+if compile:                                                                                                                                                                                                   
+    print("compiling the model... (takes a ~minute)")                                                                                                                                                       
+    unoptimized_model = model                                                                                                                                                                                 
     model = torch.compile(model) # requires PyTorch 2.0
-
-# wrap model into DDP container
-if ddp:
-    model = DDP(model, device_ids=[ddp_local_rank])
-
-# helps estimate an arbitrarily accurate loss over either split using many batches
-@torch.no_grad()
-def estimate_loss():
-    out = {}
+                                                                                                                                                                                                              
+# wrap model into DDP container                                                                                                                                                                             
+if ddp:                                                                                                                                                                                                       
+    model = DDP(model, device_ids=[ddp_local_rank])                                                                                                                                                         
+                                                                                                                                                                                                              
+# helps estimate an arbitrarily accurate loss over either split using many batches                                                                                                                            
+@torch.no_grad()                                                                                                                                                                                              
+def estimate_loss():                                                                                                                                                                                          
+    out = {}                                                                                                                                                                                                  
     model.eval()
-    for split in ['train', 'val']:
-        losses = torch.zeros(eval_iters)
-        for k in range(eval_iters):
+    for split in ['train', 'val']:                                                                                                                                                                            
+        losses = torch.zeros(eval_iters)                                                                                                                                                                    
+        for k in range(eval_iters):                                                                                                                                                                           
             X, Y = get_batch(split)
-            with ctx:
-                logits, loss = model(X, Y)
+            with ctx:                                                                                                                                                                                         
+                logits, loss = model(X, Y)                                                                                                                                                                    
             losses[k] = loss.item()
-        out[split] = losses.mean()
-    model.train()
-    return out
+        out[split] = losses.mean()                                                                                                                                                                            
+    model.train()                                                                                                                                                                                           
+    return out                                                                                                                                                                                                
 
-# learning rate decay scheduler (cosine with warmup)
-def get_lr(it):
-    # 1) linear warmup for warmup_iters steps
+# learning rate decay scheduler (cosine with warmup)                                                                                                                                                          
+def get_lr(it):                                                                                                                                                                                             
+    # 1) linear warmup for warmup_iters steps                                                                                                                                                                 
     if it < warmup_iters:
-        return learning_rate * (it + 1) / (warmup_iters + 1)
-    # 2) if it > lr_decay_iters, return min learning rate
-    if it > lr_decay_iters:
-        return min_lr
-    # 3) in between, use cosine decay down to min learning rate
-    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
+        return learning_rate * (it + 1) / (warmup_iters + 1)                                                                                                                                                  
+    # 2) if it > lr_decay_iters, return min learning rate                                                                                                                                                     
+    if it > lr_decay_iters:                                                                                                                                                                                   
+        return min_lr                                                                                                                                                                                         
+    # 3) in between, use cosine decay down to min learning rate                                                                                                                                               
+    decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)                                                                                                                                       
     assert 0 <= decay_ratio <= 1
-    coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio)) # coeff ranges 0..1
-    return min_lr + coeff * (learning_rate - min_lr)
-
-# logging
-if wandb_log and master_process:
-    import wandb
+    coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio)) # coeff ranges 0..1                                                                                                                                 
+    return min_lr + coeff * (learning_rate - min_lr)                                                                                                                                                          
+                                                                                                                                                                                                              
+# logging                                                                                                                                                                                                     
+if wandb_log and master_process:                                                                                                                                                                            
+    import wandb                                                                                                                                                                                              
     wandb.init(project=wandb_project, name=wandb_run_name, config=config)
-
-# training loop
-X, Y = get_batch('train') # fetch the very first batch
-t0 = time.time()
-local_iter_num = 0 # number of iterations in the lifetime of this process
+                                                                                                                                                                                                              
+# training loop                                                                                                                                                                                             
+X, Y = get_batch('train') # fetch the very first batch                                                                                                                                                        
+t0 = time.time()                                                                                                                                                                                            
+local_iter_num = 0 # number of iterations in the lifetime of this process                                                                                                                                     
 raw_model = model.module if ddp else model # unwrap DDP container if needed
-running_mfu = -1.0
-while True:
-
-    # determine and set the learning rate for this iteration
-    lr = get_lr(iter_num) if decay_lr else learning_rate
-    for param_group in optimizer.param_groups:
-        param_group['lr'] = lr
-
-    # evaluate the loss on train/val sets and write checkpoints
-    if iter_num % eval_interval == 0 and master_process:
-        losses = estimate_loss()
-        print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
-        if wandb_log:
+running_mfu = -1.0                                                                                                                                                                                            
+while True:                                                                                                                                                                                                   
+                                                                                                                                                                                                              
+    # determine and set the learning rate for this iteration                                                                                                                                                  
+    lr = get_lr(iter_num) if decay_lr else learning_rate                                                                                                                                                    
+    for param_group in optimizer.param_groups:                                                                                                                                                                
+        param_group['lr'] = lr                                                                                                                                                                              
+                                                                                                                                                                                                              
+    # evaluate the loss on train/val sets and write checkpoints                                                                                                                                               
+    if iter_num % eval_interval == 0 and master_process:                                                                                                                                                      
+        losses = estimate_loss()                                                                                                                                                                              
+        print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")                                                                                                           
+        if wandb_log:                                                                                                                                                                                         
             wandb.log({
-                "iter": iter_num,
-                "train/loss": losses['train'],
-                "val/loss": losses['val'],
-                "lr": lr,
-                "mfu": running_mfu*100, # convert to percentage
-            })
-        if losses['val'] < best_val_loss or always_save_checkpoint:
-            best_val_loss = losses['val']
-            if iter_num > 0:
-                checkpoint = {
-                    'model': raw_model.state_dict(),
-                    'optimizer': optimizer.state_dict(),
+                "iter": iter_num,                                                                                                                                                                             
+                "train/loss": losses['train'],                                                                                                                                                              
+                "val/loss": losses['val'],                                                                                                                                                                    
+                "lr": lr,                                                                                                                                                                                   
+                "mfu": running_mfu*100,
+            })                                                                                                                                                                                                
+        if losses['val'] < best_val_loss:
+            best_val_loss = losses['val']                                                                                                                                                                     
+            if iter_num > 0:                                                                                                                                                                                  
+                ckpt = {
+                    'model': raw_model.state_dict(),                                                                                                                                                          
+                    'optimizer': optimizer.state_dict(),                                                                                                                                                      
                     'model_args': model_args,
-                    'iter_num': iter_num,
-                    'best_val_loss': best_val_loss,
+                    'iter_num': iter_num,                                                                                                                                                                     
+                    'best_val_loss': best_val_loss,                                                                                                                                                         
                     'config': config,
-                }
-                print(f"saving checkpoint to {out_dir}")
-                torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
-    if iter_num == 0 and eval_only:
+                }                                                                                                                                                                                             
+                print(f"saving best checkpoint to {out_dir}")
+                torch.save(ckpt, os.path.join(out_dir, 'best.pt'))                                                                                                                                            
+    if iter_num == 0 and eval_only:                                                                                                                                                                           
         break
-
-    # forward backward update, with optional gradient accumulation to simulate larger batch size
-    # and using the GradScaler if data type is float16
-    for micro_step in range(gradient_accumulation_steps):
-        if ddp:
-            # in DDP training we only need to sync gradients at the last micro step.
-            # the official way to do this is with model.no_sync() context manager, but
-            # I really dislike that this bloats the code and forces us to repeat code
-            # looking at the source of that context manager, it just toggles this variable
+                                                                                                                                                                                                              
+    # forward backward update, with optional gradient accumulation to simulate larger batch size                                                                                                              
+    # and using the GradScaler if data type is float16                                                                                                                                                        
+    for micro_step in range(gradient_accumulation_steps):                                                                                                                                                     
+        if ddp:                                                                                                                                                                                               
             model.require_backward_grad_sync = (micro_step == gradient_accumulation_steps - 1)
-        with ctx:
-            logits, loss = model(X, Y)
-            loss = loss / gradient_accumulation_steps # scale the loss to account for gradient accumulation
-        # immediately async prefetch next batch while model is doing the forward pass on the GPU
-        X, Y = get_batch('train')
-        # backward pass, with gradient scaling if training in fp16
-        scaler.scale(loss).backward()
-    # clip the gradient
-    if grad_clip != 0.0:
-        scaler.unscale_(optimizer)
-        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
-    # step the optimizer and scaler if training in fp16
+        with ctx:                                                                                                                                                                                             
+            logits, loss = model(X, Y)                                                                                                                                                                      
+            loss = loss / gradient_accumulation_steps # scale the loss to account for gradient accumulation                                                                                                   
+        # immediately async prefetch next batch while model is doing the forward pass on the GPU                                                                                                            
+        X, Y = get_batch('train')                                                                                                                                                                             
+        # backward pass, with gradient scaling if training in fp16                                                                                                                                          
+        scaler.scale(loss).backward()                                                                                                                                                                         
+    # clip the gradient                                                                                                                                                                                     
+    if grad_clip != 0.0:                                                                                                                                                                                      
+        scaler.unscale_(optimizer)                                                                                                                                                                          
+        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)                                                                                                                                         
+    # step the optimizer and scaler if training in fp16                                                                                                                                                       
     scaler.step(optimizer)
-    scaler.update()
-    # flush the gradients as soon as we can, no need for this memory anymore
-    optimizer.zero_grad(set_to_none=True)
-
-    # timing and logging
-    t1 = time.time()
-    dt = t1 - t0
+    scaler.update()                                                                                                                                                                                           
+    # flush the gradients as soon as we can, no need for this memory anymore                                                                                                                                
+    optimizer.zero_grad(set_to_none=True)                                                                                                                                                                     
+                                                                                                                                                                                                              
+    # timing and logging                                                                                                                                                                                      
+    t1 = time.time()                                                                                                                                                                                          
+    dt = t1 - t0                                                                                                                                                                                            
     t0 = t1
-    if iter_num % log_interval == 0 and master_process:
-        # get loss as float. note: this is a CPU-GPU sync point
-        # scale up to undo the division above, approximating the true total loss (exact would have been a sum)
+    if iter_num % log_interval == 0 and master_process:                                                                                                                                                       
         lossf = loss.item() * gradient_accumulation_steps
-        if local_iter_num >= 5: # let the training loop settle a bit
-            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)
-            running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu
-        print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")
-    iter_num += 1
-    local_iter_num += 1
+        if local_iter_num >= 5:                                                                                                                                                                               
+            mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)                                                                                                                      
+            running_mfu = mfu if running_mfu == -1.0 else 0.9*running_mfu + 0.1*mfu                                                                                                                           
+        print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms, mfu {running_mfu*100:.2f}%")                                                                                                         
+        if wandb_log and master_process:                                                                                                                                                                      
+            wandb.log({                                                                                                                                                                                       
+                "iter": iter_num,                                                                                                                                                                             
+                "train/loss": lossf,                                                                                                                                                                        
+                "lr": lr,                                                                                                                                                                                     
+                "mfu": running_mfu * 100,
+            })                                                                                                                                                                                                
+                                                                                                                                                                                                            
+    # periodic checkpoint
+    if iter_num > 0 and iter_num % checkpoint_interval == 0 and master_process:
+        ckpt = {                                                                                                                                                                                              
+            'model': raw_model.state_dict(),
+            'optimizer': optimizer.state_dict(),                                                                                                                                                              
+            'model_args': model_args,                                                                                                                                                                       
+            'iter_num': iter_num,
+            'best_val_loss': best_val_loss,                                                                                                                                                                   
+            'config': config,
+        }                                                                                                                                                                                                     
+        ckpt_path = os.path.join(out_dir, f'ckpt_{iter_num:07d}.pt')                                                                                                                                        
+        print(f"saving periodic checkpoint to {ckpt_path}")
+        torch.save(ckpt, ckpt_path)                                                                                                                                                                           
 
-    # termination conditions
+    iter_num += 1                                                                                                                                                                                             
+    local_iter_num += 1                                                                                                                                                                                     
+                                                                                                                                                                                                              
+    # termination conditions                                                                                                                                                                                
     if iter_num > max_iters:
         break
 
+# save last checkpoint                                                                                                                                                                                        
+if master_process:
+    ckpt = {                                                                                                                                                                                                  
+        'model': raw_model.state_dict(),                                                                                                                                                                    
+        'optimizer': optimizer.state_dict(),
+        'model_args': model_args,
+        'iter_num': iter_num,
+        'best_val_loss': best_val_loss,
+        'config': config,                                                                                                                                                                                     
+    }
+    print(f"saving last checkpoint to {out_dir}")                                                                                                                                                             
+    torch.save(ckpt, os.path.join(out_dir, 'last.pt'))                                                                                                                                                      
+                                                                                                                                                                                                              
 if ddp:
-    destroy_process_group()
+    destroy_process_group() 


### PR DESCRIPTION
## Summary

This PR completes the Week3 nanoGPT engineering task:

- Adds configurable MLP activation: GELU / ReLU / SiLU.
- Adds configurable LayerNorm position: Pre-LN / Post-LN.
- Adds a toy MoE MLP with N experts, top-k routing, and load balancing loss.
- Logs `train/ce_loss` and `moe/aux_loss` to W&B.
- Adds optimizer selection for AdamW / SGD.
- Adds a Week3 experiment script for Day2, Day3, and Day4 runs.

## Files Changed

- `model.py`
  - Configurable activation.
  - `ToyMoEMLP`.
  - Switch-style load balancing loss.
  - Dense/MoE MLP selection.
  - Pre-LN/Post-LN switch.
  - MoE aux loss aggregation.
  - AdamW/SGD optimizer selection.

- `train.py`
  - Passes new Hydra config values into `GPTConfig`.
  - Logs CE loss and MoE aux loss.
  - Supports W&B group/tags/notes.

- `config/model/nanogpt_small.yaml`
  - Adds `activation`, `norm_position`, `use_moe`, `moe_n_experts`, `moe_top_k`, `moe_aux_loss_weight`.

- `config/optim/adamw.yaml`
  - Adds `name` and `momentum` for optimizer switching.

- `config/config.yaml`
  - Adds W&B grouping metadata.

- `scripts/run_week3_experiments.sh`
  - Runs Week3 Day2/Day3/Day4 comparison experiments.

## Verification

Static check:

```bash
python -m py_compile model.py train.py
```

Forward sanity check:

```bash
python - <<'PY'
import torch
from model import GPT, GPTConfig

for kwargs in [
    dict(),
    dict(activation="silu"),
    dict(norm_position="post"),
    dict(use_moe=True, moe_n_experts=4, moe_top_k=2),
    dict(use_moe=True, moe_n_experts=4, moe_top_k=1),
]:
    cfg = GPTConfig(block_size=64, vocab_size=100, n_layer=2, n_head=2, n_embd=64, **kwargs)
    m = GPT(cfg)
    x = torch.randint(0, 100, (2, 64))
    y = torch.randint(0, 100, (2, 64))
    logits, loss = m(x, y)
    print(kwargs or {"baseline": True}, logits.shape, round(loss.item(), 4), round(float(m.last_aux_loss), 4))
PY
```

MoE smoke test:

```bash
python train.py \
  wandb_log=false \
  optim.max_iters=5 \
  eval_interval=5 \
  eval_iters=2 \
  log_interval=1 \
  out_dir=/root/autodl-tmp/ckpt/week3_smoke \
  model.use_moe=true \
  model.moe_top_k=2
```

Result: MoE trains for 5 steps successfully and loss decreases from about 4.19 to about 4.06 without NaN.

## W&B

Project:

https://wandb.ai/grace2056320586-guangdong-technionisrael-institute-of-te/nanogpt

Key runs:

- Day2 baseline / lr / batch size / dropout / SGD runs.
- Day3 SiLU / ReLU / head count / Post-LN runs.
- Day4 dense / MoE K=1 / MoE K=2 runs.
