### PR TITLE
model: handle temperature=0 in generate with greedy argmax

### DIFF
--- a/model.py
+++ b/model.py
@@ -315,15 +315,19 @@ class GPT(nn.Module):
             # forward the model to get the logits for the index in the sequence
             logits, _ = self(idx_cond)
             # pluck the logits at the final step and scale by desired temperature
-            logits = logits[:, -1, :] / temperature
-            # optionally crop the logits to only the top k options
-            if top_k is not None:
-                v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
-                logits[logits < v[:, [-1]]] = -float('Inf')
-            # apply softmax to convert logits to (normalized) probabilities
-            probs = F.softmax(logits, dim=-1)
-            # sample from the distribution
-            idx_next = torch.multinomial(probs, num_samples=1)
+            logits = logits[:, -1, :]
+            if temperature == 0.0:
+                idx_next = torch.argmax(logits, dim=-1, keepdim=True)
+            else:
+                logits = logits / temperature
+                # optionally crop the logits to only the top k options
+                if top_k is not None:
+                    v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
+                    logits[logits < v[:, [-1]]] = -float('Inf')
+                # apply softmax to convert logits to (normalized) probabilities
+                probs = F.softmax(logits, dim=-1)
+                # sample from the distribution
+                idx_next = torch.multinomial(probs, num_samples=1)
             # append sampled index to the running sequence and continue
             idx = torch.cat((idx, idx_next), dim=1)
 


### PR DESCRIPTION
Fixes #738.

`GPT.generate()` previously divided logits by `temperature` unconditionally, so `temperature=0` caused invalid probabilities and runtime failure.

This change adds a small greedy-decoding path:
- if `temperature == 0.0`, select `argmax` directly
- otherwise keep existing temperature scaling + top-k + multinomial sampling

This preserves current behavior for nonzero temperatures while making `temperature=0` deterministic and non-crashing.