### PR TITLE
switch model to eval mode during inference to prevent unwanted dropout

### DIFF
--- a/model.py
+++ b/model.py
@@ -309,22 +309,39 @@ class GPT(nn.Module):
         the sequence max_new_tokens times, feeding the predictions back into the model each time.
         Most likely you'll want to make sure to be in model.eval() mode of operation for this.
         """
+
+        # record and switch to eval mode
+        was_training = self.training
+        self.eval()
+
         for _ in range(max_new_tokens):
             # if the sequence context is growing too long we must crop it at block_size
             idx_cond = idx if idx.size(1) <= self.config.block_size else idx[:, -self.config.block_size:]
             # forward the model to get the logits for the index in the sequence
             logits, _ = self(idx_cond)
+
             # pluck the logits at the final step and scale by desired temperature
-            logits = logits[:, -1, :] / temperature
-            # optionally crop the logits to only the top k options
-            if top_k is not None:
-                v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
-                logits[logits < v[:, [-1]]] = -float('Inf')
-            # apply softmax to convert logits to (normalized) probabilities
-            probs = F.softmax(logits, dim=-1)
-            # sample from the distribution
-            idx_next = torch.multinomial(probs, num_samples=1)
+            if temperature == 0.0:
+                # Greedy Search (temperature == 0)
+                idx_next = torch.argmax(logits, dim=-1, keepdim=True)
+            else:
+                logits = logits[:, -1, :] / temperature
+                # optionally crop the logits to only the top k options
+                if top_k is not None:
+                    assert top_k > 0, f"top_k must be > 0, but got {top_k}"
+                    v, _ = torch.topk(logits, min(top_k, logits.size(-1)))
+                    logits[logits < v[:, [-1]]] = -float('Inf')
+                # apply softmax to convert logits to (normalized) probabilities
+                probs = F.softmax(logits, dim=-1)
+                # sample from the distribution
+                idx_next = torch.multinomial(probs, num_samples=1)
+
             # append sampled index to the running sequence and continue
             idx = torch.cat((idx, idx_next), dim=1)
+
+
+        # switch back to training mode
+        if was_training:
+            self.train()
 
         return idx


### PR DESCRIPTION

fix(generate): 
1,switch model to eval mode during inference to prevent unwanted dropout.
2, check parameter top_k > 0.
3, support Greedy Search (temperature == 0).